### PR TITLE
17 graphicspso

### DIFF
--- a/voxen/App.cpp
+++ b/voxen/App.cpp
@@ -79,7 +79,8 @@ bool App::Initialize()
 	if (!InitGUI())
 		return false;
 
-	InitScene();
+	if (!InitScene())
+		return false;
 
 	return true;
 }
@@ -106,6 +107,7 @@ void App::Run()
 			Update(ImGui::GetIO().DeltaTime);
 			Render(); // 우리가 구현한 렌더링
 
+			// GUI 렌더링을 위한 RTV 재설정
 			Graphics::context->OMSetRenderTargets(
 				1, Graphics::backBufferRTV.GetAddressOf(), nullptr);
 			ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData()); // GUI 렌더링

--- a/voxen/DXUtils.h
+++ b/voxen/DXUtils.h
@@ -219,42 +219,6 @@ public:
 		return true;
 	}
 
-	static bool CreateDepthStencilBuffer(
-		ComPtr<ID3D11Texture2D>& buffer, UINT width, UINT height, bool isMSAA)
-	{
-		D3D11_TEXTURE2D_DESC desc;
-		ZeroMemory(&desc, sizeof(desc));
-
-		desc.Width = width;
-		desc.Height = height;
-		desc.MipLevels = desc.ArraySize = 1;
-		desc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
-		if (isMSAA) {
-			UINT qualityLevel = 0;
-			HRESULT ret = Graphics::device->CheckMultisampleQualityLevels(
-				DXGI_FORMAT_D24_UNORM_S8_UINT, 4, &qualityLevel);
-			if (FAILED(ret)) {
-				std::cout << "failed check MSSA" << std::endl;
-				return false;
-			}
-
-			desc.SampleDesc.Count = 4;
-			desc.SampleDesc.Quality = qualityLevel - 1;
-		}
-		else {
-			desc.SampleDesc.Count = 1;
-			desc.SampleDesc.Quality = 0;
-		}
-
-		desc.Usage = D3D11_USAGE_DEFAULT;
-		desc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
-		HRESULT ret = Graphics::device->CreateTexture2D(&desc, nullptr, buffer.GetAddressOf());
-		if (FAILED(ret))
-			return false;
-
-		return true;
-	}
-
 	static ComPtr<ID3D11Texture2D> CreateStagingTexture(UINT width, UINT height,
 		std::vector<uint8_t>& image, UINT mipLevels = 1, UINT arraySize = 1,
 		DXGI_FORMAT format = DXGI_FORMAT_R8G8B8A8_UNORM, size_t pixelSize = sizeof(uint8_t) * 4)

--- a/voxen/Graphics.cpp
+++ b/voxen/Graphics.cpp
@@ -92,13 +92,12 @@ bool Graphics::InitGraphicsCore(DXGI_FORMAT pixelFormat, HWND& hwnd, UINT width,
 	D3D_FEATURE_LEVEL featureLevel;
 
 	HRESULT ret = D3D11CreateDevice(0, driverType, 0, deviceFlags, levels, ARRAYSIZE(levels),
-		D3D11_SDK_VERSION, device.GetAddressOf(), &featureLevel,
-		context.GetAddressOf());
+		D3D11_SDK_VERSION, device.GetAddressOf(), &featureLevel, context.GetAddressOf());
 	if (FAILED(ret)) {
 		std::cout << "failed create device and context" << std::endl;
 		return false;
 	}
-	
+
 	DXGI_SWAP_CHAIN_DESC desc;
 	ZeroMemory(&desc, sizeof(desc));
 	desc.BufferDesc.Width = width;
@@ -116,8 +115,8 @@ bool Graphics::InitGraphicsCore(DXGI_FORMAT pixelFormat, HWND& hwnd, UINT width,
 	desc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_MODE_SWITCH;
 
 	ret = D3D11CreateDeviceAndSwapChain(NULL, driverType, 0, deviceFlags, levels, ARRAYSIZE(levels),
-		D3D11_SDK_VERSION, &desc, swapChain.GetAddressOf(),
-		device.GetAddressOf(), &featureLevel, context.GetAddressOf());
+		D3D11_SDK_VERSION, &desc, swapChain.GetAddressOf(), device.GetAddressOf(), &featureLevel,
+		context.GetAddressOf());
 
 	if (FAILED(ret)) {
 		std::cout << "failed create swapchain" << std::endl;
@@ -145,8 +144,8 @@ bool Graphics::InitRenderTargetBuffers(UINT width, UINT height)
 {
 	// backBuffer
 	swapChain->GetBuffer(0, IID_PPV_ARGS(backBuffer.GetAddressOf()));
-	HRESULT ret = device->CreateRenderTargetView(
-		backBuffer.Get(), nullptr, backBufferRTV.GetAddressOf());
+	HRESULT ret =
+		device->CreateRenderTargetView(backBuffer.Get(), nullptr, backBufferRTV.GetAddressOf());
 	if (FAILED(ret)) {
 		std::cout << "failed create render target view" << std::endl;
 		return false;
@@ -202,8 +201,7 @@ bool Graphics::InitShaderResourceBuffers()
 		return false;
 	}
 
-	if (!DXUtils::CreateTextureFromFile(
-			topBuffer, topSRV, "../assets/grass_block_top.png")) {
+	if (!DXUtils::CreateTextureFromFile(topBuffer, topSRV, "../assets/grass_block_top.png")) {
 		std::cout << "failed create texture from file" << std::endl;
 		return false;
 	}
@@ -214,8 +212,7 @@ bool Graphics::InitShaderResourceBuffers()
 		return false;
 	}
 
-	if (!DXUtils::CreateTextureFromFile(
-			dirtBuffer, dirtSRV, "../assets/dirt.png")) {
+	if (!DXUtils::CreateTextureFromFile(dirtBuffer, dirtSRV, "../assets/dirt.png")) {
 		std::cout << "failed create texture from file" << std::endl;
 		return false;
 	}
@@ -363,7 +360,7 @@ bool Graphics::InitDepthStencilStates()
 	return true;
 }
 
-void Graphics::InitGraphicsPSO() 
+void Graphics::InitGraphicsPSO()
 {
 	// basicPSO
 	basicPSO.inputLayout = basicIL;
@@ -378,20 +375,24 @@ void Graphics::InitGraphicsPSO()
 	skyboxPSO = basicPSO;
 	skyboxPSO.vertexShader = skyboxVS;
 	skyboxPSO.pixelShader = skyboxPS;
+	skyboxPSO.samplerStates.clear();
 }
 
 void Graphics::SetPipelineStates(GraphicsPSO& pso)
-{ 
+{
 	context->IASetInputLayout(pso.inputLayout.Get());
 	context->IASetPrimitiveTopology(pso.topology);
 
 	context->VSSetShader(pso.vertexShader.Get(), nullptr, 0);
-	
+
 	context->RSSetState(pso.rasterizerState.Get());
 
 	context->PSSetShader(pso.pixelShader.Get(), nullptr, 0);
 
-	context->PSSetSamplers(0, (UINT)pso.samplerStates.size(), pso.samplerStates.data());
+	if (pso.samplerStates.empty())
+		context->PSSetSamplers(0, 0, nullptr);
+	else
+		context->PSSetSamplers(0, (UINT)pso.samplerStates.size(), pso.samplerStates.data());
 
 	context->OMSetDepthStencilState(pso.depthStencilState.Get(), 0);
 }

--- a/voxen/Graphics.cpp
+++ b/voxen/Graphics.cpp
@@ -137,7 +137,7 @@ bool Graphics::InitRenderTargetBuffers(UINT width, UINT height)
 {
 	// backBuffer
 	swapChain->GetBuffer(0, IID_PPV_ARGS(backBuffer.GetAddressOf()));
-	HRESULT ret = Graphics::device->CreateRenderTargetView(
+	HRESULT ret = device->CreateRenderTargetView(
 		backBuffer.Get(), nullptr, backBufferRTV.GetAddressOf());
 	if (FAILED(ret)) {
 		std::cout << "failed create render target view" << std::endl;
@@ -164,7 +164,9 @@ bool Graphics::InitRenderTargetBuffers(UINT width, UINT height)
 bool Graphics::InitDepthStencilBuffers(UINT width, UINT height)
 {
 	// basic DSV
-	if (!DXUtils::CreateDepthStencilBuffer(basicDepthBuffer, width, height, true)) {
+	DXGI_FORMAT format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+	D3D11_BIND_FLAG bindFlag = D3D11_BIND_DEPTH_STENCIL;
+	if (!DXUtils::CreateTextureBuffer(basicDepthBuffer, width, height, true, format, bindFlag)) {
 		std::cout << "failed create depth stencil buffer" << std::endl;
 		return false;
 	}

--- a/voxen/Graphics.cpp
+++ b/voxen/Graphics.cpp
@@ -64,6 +64,14 @@ namespace Graphics {
 
 	// Viewport
 	D3D11_VIEWPORT basicViewport;
+
+
+	// PSO
+	void InitGraphicsPSO();
+	void SetPipelineStates(GraphicsPSO& pso);
+
+	GraphicsPSO basicPSO;
+	GraphicsPSO skyboxPSO;
 }
 
 
@@ -355,3 +363,35 @@ bool Graphics::InitDepthStencilStates()
 	return true;
 }
 
+void Graphics::InitGraphicsPSO() 
+{
+	// basicPSO
+	basicPSO.inputLayout = basicIL;
+	basicPSO.topology = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+	basicPSO.vertexShader = basicVS;
+	basicPSO.rasterizerState = solidRS;
+	basicPSO.pixelShader = basicPS;
+	basicPSO.samplerStates.push_back(pointClampSS.Get());
+	basicPSO.depthStencilState = basicDSS;
+
+	// skyboxPSO
+	skyboxPSO = basicPSO;
+	skyboxPSO.vertexShader = skyboxVS;
+	skyboxPSO.pixelShader = skyboxPS;
+}
+
+void Graphics::SetPipelineStates(GraphicsPSO& pso)
+{ 
+	context->IASetInputLayout(pso.inputLayout.Get());
+	context->IASetPrimitiveTopology(pso.topology);
+
+	context->VSSetShader(pso.vertexShader.Get(), nullptr, 0);
+	
+	context->RSSetState(pso.rasterizerState.Get());
+
+	context->PSSetShader(pso.pixelShader.Get(), nullptr, 0);
+
+	context->PSSetSamplers(0, (UINT)pso.samplerStates.size(), pso.samplerStates.data());
+
+	context->OMSetDepthStencilState(pso.depthStencilState.Get(), 0);
+}

--- a/voxen/Graphics.h
+++ b/voxen/Graphics.h
@@ -3,6 +3,8 @@
 #include <d3d11.h>
 #include <wrl.h>
 
+#include "GraphicsPSO.h"
+
 using namespace Microsoft::WRL;
 
 namespace Graphics {
@@ -91,4 +93,11 @@ namespace Graphics {
 	extern bool InitRasterizerStates();
 	extern bool InitSamplerStates();
 	extern bool InitDepthStencilStates();
+
+
+	// PSO
+	extern void InitGraphicsPSO();
+	extern void SetPipelineStates(GraphicsPSO& pso);
+	extern GraphicsPSO basicPSO;
+	extern GraphicsPSO skyboxPSO;
 }

--- a/voxen/Graphics.h
+++ b/voxen/Graphics.h
@@ -77,7 +77,7 @@ namespace Graphics {
 	extern bool InitGraphicsCore(DXGI_FORMAT pixelFormat, HWND& hwnd, UINT width, UINT height);
 	
 
-	// RTV(+viewport), DSV, SRV (+ UAV ...)
+	// RTV, DSV, SRV (+ UAV ...)
 	extern bool InitGraphicsBuffer(UINT width, UINT height);
 	extern bool InitRenderTargetBuffers(UINT width, UINT height);
 	extern bool InitDepthStencilBuffers(UINT width, UINT height);

--- a/voxen/GraphicsPSO.cpp
+++ b/voxen/GraphicsPSO.cpp
@@ -1,0 +1,34 @@
+#include "GraphicsPSO.h"
+
+GraphicsPSO::GraphicsPSO()
+	: inputLayout(nullptr), topology(D3D_PRIMITIVE_TOPOLOGY_UNDEFINED), vertexShader(nullptr),
+	  rasterizerState(nullptr), pixelShader(nullptr), samplerStates(), depthStencilState(nullptr)
+{
+}
+
+GraphicsPSO::GraphicsPSO(const GraphicsPSO& rhs)
+	: inputLayout(rhs.inputLayout), topology(rhs.topology), vertexShader(rhs.vertexShader),
+	  rasterizerState(rhs.rasterizerState), pixelShader(rhs.pixelShader),
+	  samplerStates(rhs.samplerStates), depthStencilState(rhs.depthStencilState)
+{
+}
+
+GraphicsPSO GraphicsPSO::operator=(const GraphicsPSO& other)
+{
+	inputLayout = other.inputLayout;
+	topology = other.topology;
+
+	vertexShader = other.vertexShader;
+
+	rasterizerState = other.rasterizerState;
+
+	pixelShader = other.pixelShader;
+
+	samplerStates = other.samplerStates;
+
+	depthStencilState = other.depthStencilState;
+
+	return *this;
+}
+
+GraphicsPSO::~GraphicsPSO() {}

--- a/voxen/GraphicsPSO.h
+++ b/voxen/GraphicsPSO.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <d3d11.h>
+#include <wrl.h>
+#include <vector>
+
+using namespace Microsoft::WRL;
+
+class GraphicsPSO
+{
+public:
+	GraphicsPSO();
+	GraphicsPSO(const GraphicsPSO& rhs);
+	GraphicsPSO operator=(const GraphicsPSO& other);
+	~GraphicsPSO();
+	
+	ComPtr<ID3D11InputLayout> inputLayout;
+	D3D11_PRIMITIVE_TOPOLOGY topology;
+
+	ComPtr<ID3D11VertexShader> vertexShader;
+
+	ComPtr<ID3D11RasterizerState> rasterizerState;
+
+	ComPtr<ID3D11PixelShader> pixelShader;
+	
+	std::vector<ID3D11SamplerState *> samplerStates;
+
+	ComPtr<ID3D11DepthStencilState> depthStencilState;
+	
+
+	/*
+	ComPtr<ID3D11HullShader> m_hullShader;
+    ComPtr<ID3D11DomainShader> m_domainShader;
+    ComPtr<ID3D11GeometryShader> m_geometryShader;
+	ComPtr<ID3D11BlendState> m_blendState;
+	float m_blendFactor[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+	UINT m_stencilRef = 0;
+	*/
+};

--- a/voxen/voxen.vcxproj
+++ b/voxen/voxen.vcxproj
@@ -148,6 +148,7 @@
     <ClCompile Include="Chunk.cpp" />
     <ClCompile Include="ChunkManager.cpp" />
     <ClCompile Include="Graphics.cpp" />
+    <ClCompile Include="GraphicsPSO.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="Skybox.cpp" />
   </ItemGroup>
@@ -157,6 +158,7 @@
     <ClInclude Include="Camera.h" />
     <ClInclude Include="Chunk.h" />
     <ClInclude Include="Graphics.h" />
+    <ClInclude Include="GraphicsPSO.h" />
     <ClInclude Include="Skybox.h" />
     <ClInclude Include="ChunkManager.h" />
     <ClInclude Include="Structure.h" />

--- a/voxen/voxen.vcxproj.filters
+++ b/voxen/voxen.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClCompile Include="Graphics.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="GraphicsPSO.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="App.h">
@@ -72,6 +75,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="Utils.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="GraphicsPSO.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
## GraphicsPSO 구현
- 아래는 PSO가 가지고 있는 데이터
```
ComPtr<ID3D11InputLayout> inputLayout;
D3D11_PRIMITIVE_TOPOLOGY topology;
ComPtr<ID3D11VertexShader> vertexShader;
ComPtr<ID3D11RasterizerState> rasterizerState;
ComPtr<ID3D11PixelShader> pixelShader;
std::vector<ID3D11SamplerState *> samplerStates;
ComPtr<ID3D11DepthStencilState> depthStencilState;

/* 추후에 생길 PSO 데이터
ComPtr<ID3D11HullShader> m_hullShader;
ComPtr<ID3D11DomainShader> m_domainShader;
ComPtr<ID3D11GeometryShader> m_geometryShader;
ComPtr<ID3D11BlendState> m_blendState;
float m_blendFactor[4] = {1.0f, 1.0f, 1.0f, 1.0f};
UINT m_stencilRef = 0;
*/
```

- GraphicsCommon에서 PSO를 선언 후 모두 초기화
```
void Graphics::InitGraphicsPSO() 
{
	// basicPSO
	basicPSO.inputLayout = basicIL;
	basicPSO.topology = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
	basicPSO.vertexShader = basicVS;
	basicPSO.rasterizerState = solidRS;
	basicPSO.pixelShader = basicPS;
	basicPSO.samplerStates.push_back(pointClampSS.Get());
	basicPSO.depthStencilState = basicDSS;

	// skyboxPSO
	skyboxPSO = basicPSO;
	skyboxPSO.vertexShader = skyboxVS;
	skyboxPSO.pixelShader = skyboxPS;
}
```

- PSO를 Pipeline State로 설정하는 로직도 갖춤
```
void Graphics::SetPipelineStates(GraphicsPSO& pso)
{ 
	context->IASetInputLayout(pso.inputLayout.Get());
	context->IASetPrimitiveTopology(pso.topology);

	context->VSSetShader(pso.vertexShader.Get(), nullptr, 0);
	
	context->RSSetState(pso.rasterizerState.Get());

	context->PSSetShader(pso.pixelShader.Get(), nullptr, 0);

	context->PSSetSamplers(0, (UINT)pso.samplerStates.size(), pso.samplerStates.data());

	context->OMSetDepthStencilState(pso.depthStencilState.Get(), 0);
}
```

- App Render 함수에서는 적절히 PSO를 이용하여 PipelineState를 설정해주면 됨
