### PR TITLE
FEAT: block type 고려 Greedy Meshing

### DIFF
--- a/voxen/Block.h
+++ b/voxen/Block.h
@@ -1,14 +1,18 @@
 #pragma once
 
+#include <stdint.h>
+
 class Block 
 {
 public:
-	Block() : m_isActive(false) {}
+	Block() : m_type(0) {}
 	~Block() {}
 
-	inline bool IsActive() { return m_isActive; }
-	inline void SetActive(bool active) { m_isActive = active; }
+	inline uint8_t GetType() { return m_type; }
+	inline void SetType(uint8_t type) { m_type = type; }
+
+	static const int BLOCK_TYPE_COUNT = 256;
 
 private:
-	bool m_isActive;
+	uint8_t m_type;
 };

--- a/voxen/Chunk.cpp
+++ b/voxen/Chunk.cpp
@@ -2,11 +2,12 @@
 #include "DXUtils.h"
 
 #include <future>
+#include <algorithm>
+#include <unordered_map>
 
 Chunk::Chunk()
 	: m_position(0.0, 0.0, 0.0), m_stride(sizeof(VoxelVertex)), m_offset(0),
-	  m_vertexBuffer(nullptr),
-	  m_indexBuffer(nullptr), m_constantBuffer(nullptr), m_isLoaded(false)
+	  m_vertexBuffer(nullptr), m_indexBuffer(nullptr), m_constantBuffer(nullptr), m_isLoaded(false)
 {
 }
 
@@ -17,23 +18,33 @@ bool Chunk::Initialize()
 	static long long sum = 0;
 	static long long count = 0;
 	auto start_time = std::chrono::steady_clock::now();
-	
+
 	// 1. make axis column bit data
-	std::vector<uint64_t> axisColBit(CHUNK_SIZE_P2 * 3, 0);
+	static uint64_t axisColBit[CHUNK_SIZE_P2 * 3];
+	std::fill(axisColBit, axisColBit + CHUNK_SIZE_P2 * 3, 0);
+	std::unordered_map<uint8_t, bool> typeMap;
+
 	for (int x = 0; x < CHUNK_SIZE_P; ++x) {
 		for (int z = 0; z < CHUNK_SIZE_P; ++z) {
 			int height = Utils::GetHeight((int)m_position.x + x - 1, (int)m_position.z + z - 1);
 
 			for (int y = 0; y < CHUNK_SIZE_P; ++y) {
-				m_blocks[x][y][z].SetActive(1 <= m_position.y + y && m_position.y + y <= height);
+				if (1 <= m_position.y + y && m_position.y + y <= height) {
+					uint8_t type = 2; // get type from TerrainGenerator
+					m_blocks[x][y][z].SetType(type);
+					typeMap[type] = true;
 
-				if (m_blocks[x][y][z].IsActive()) {
-					// x dir column
-					axisColBit[Utils::Utils::GetIndexFrom3D(0, y, z, CHUNK_SIZE_P)] |= (1ULL << x);
-					// y dir column
-					axisColBit[Utils::Utils::GetIndexFrom3D(1, z, x, CHUNK_SIZE_P)] |= (1ULL << y);
-					// z dir column
-					axisColBit[Utils::Utils::GetIndexFrom3D(2, y, x, CHUNK_SIZE_P)] |= (1ULL << z);
+					if (type) { // type == 0 is Air
+						// x dir column
+						axisColBit[Utils::Utils::GetIndexFrom3D(0, y, z, CHUNK_SIZE_P)] |=
+							(1ULL << x);
+						// y dir column
+						axisColBit[Utils::Utils::GetIndexFrom3D(1, z, x, CHUNK_SIZE_P)] |=
+							(1ULL << y);
+						// z dir column
+						axisColBit[Utils::Utils::GetIndexFrom3D(2, y, x, CHUNK_SIZE_P)] |=
+							(1ULL << z);
+					}
 				}
 			}
 		}
@@ -47,7 +58,9 @@ bool Chunk::Initialize()
 	// 3: y axis & top->bottom side (+ => - : dir -)
 	// 4: z axis & front->back side (- => + : dir +)
 	// 5: z axis & back->front side (+ => - : dir -)
-	std::vector<uint64_t> cullColBit(CHUNK_SIZE_P2 * 6, 0);
+	static uint64_t cullColBit[CHUNK_SIZE_P2 * 6];
+	std::fill(cullColBit, cullColBit + CHUNK_SIZE_P2 * 6, 0);
+
 	for (int axis = 0; axis < 3; ++axis) {
 		for (int h = 1; h < CHUNK_SIZE_P - 1; ++h) {
 			for (int w = 1; w < CHUNK_SIZE_P - 1; ++w) {
@@ -74,7 +87,10 @@ bool Chunk::Initialize()
 	 *  | 1    2    3 |/
 	 *  ---------------
 	 */
-	std::vector<uint64_t> faceColbit(CHUNK_SIZE2 * 6, 0);
+	static uint64_t faceColBit[Block::BLOCK_TYPE_COUNT][CHUNK_SIZE2 * 6];
+	for (const auto& p : typeMap)
+		std::fill(faceColBit[p.first], faceColBit[p.first] + CHUNK_SIZE2 * 6, 0);
+
 	for (int face = 0; face < 6; ++face) {
 		for (int h = 0; h < CHUNK_SIZE; ++h) {
 			for (int w = 0; w < CHUNK_SIZE; ++w) {
@@ -82,12 +98,22 @@ bool Chunk::Initialize()
 					cullColBit[Utils::GetIndexFrom3D(face, h + 1, w + 1, CHUNK_SIZE_P)];
 				culledBit = culledBit >> 1;					   // 33bit: P,CHUNK_SIZE
 				culledBit = culledBit & ~(1ULL << CHUNK_SIZE); // 32bit: CHUNK_SIZE
-
 				while (culledBit) {
 					int bitPos = Utils::TrailingZeros(culledBit); // 1110001000 -> trailing zero : 3
 					culledBit = culledBit & (culledBit - 1ULL);	  // 1110000000
 
-					faceColbit[Utils::GetIndexFrom3D(face, bitPos, w, CHUNK_SIZE)] |= (1ULL << h);
+					uint8_t type = 0; 
+					if (face < 2) {
+						type = m_blocks[bitPos+1][h+1][w+1].GetType();
+					}
+					else if (face < 4) {
+						type = m_blocks[w+1][bitPos+1][h+1].GetType();
+					}
+					else { // face < 6
+						type = m_blocks[w+1][h+1][bitPos+1].GetType();
+					}
+
+					faceColBit[type][Utils::GetIndexFrom3D(face, bitPos, w, CHUNK_SIZE)] |= (1ULL << h);
 				}
 			}
 		}
@@ -98,48 +124,55 @@ bool Chunk::Initialize()
 	// face 0, 1 : left-right
 	// face 2, 3 : top-bottom
 	// face 4, 5 : front-back
-	for (int face = 0; face < 6; ++face) {
-		for (int s = 0; s < CHUNK_SIZE; ++s) {
-			for (int i = 0; i < CHUNK_SIZE; ++i) {
-				uint64_t faceBit = faceColbit[Utils::GetIndexFrom3D(face, s, i, CHUNK_SIZE)];
-				int step = 0;
-				while (step < CHUNK_SIZE) {						   // 111100011100
-					step += Utils::TrailingZeros(faceBit >> step); // 1111000111|00| -> 2
-					if (step >= CHUNK_SIZE)
-						break;
-
-					int ones = Utils::TrailingOnes((faceBit >> step));	// 1111000|111|00 -> 3
-					uint64_t submask = ((1ULL << ones) - 1ULL) << step; // 111 << 2 -> 11100
-
-					int w = 1;
-					while (i + w < CHUNK_SIZE) {
-						uint64_t cb =
-							faceColbit[Utils::GetIndexFrom3D(face, s, i + w, CHUNK_SIZE)] & submask;
-						if (cb != submask)
+	for (const auto& p : typeMap) {
+		uint8_t type = p.first;
+		for (int face = 0; face < 6; ++face) {
+			for (int s = 0; s < CHUNK_SIZE; ++s) {
+				for (int i = 0; i < CHUNK_SIZE; ++i) {
+					uint64_t faceBit =
+						faceColBit[type][Utils::GetIndexFrom3D(face, s, i, CHUNK_SIZE)];
+					int step = 0;
+					while (step < CHUNK_SIZE) {						   // 111100011100
+						step += Utils::TrailingZeros(faceBit >> step); // 1111000111|00| -> 2
+						if (step >= CHUNK_SIZE)
 							break;
 
-						faceColbit[Utils::GetIndexFrom3D(face, s, i + w, CHUNK_SIZE)] &= (~submask);
-						w++;
+						int ones = Utils::TrailingOnes((faceBit >> step));	// 1111000|111|00 -> 3
+						uint64_t submask = ((1ULL << ones) - 1ULL) << step; // 111 << 2 -> 11100
+
+						int w = 1;
+						while (i + w < CHUNK_SIZE) {
+							uint64_t cb = faceColBit[type][Utils::GetIndexFrom3D(
+											  face, s, i + w, CHUNK_SIZE)] &
+										  submask;
+							if (cb != submask)
+								break;
+
+							faceColBit[type][Utils::GetIndexFrom3D(face, s, i + w, CHUNK_SIZE)] &=
+								(~submask);
+							w++;
+						}
+
+						if (face == 0)
+							CreateQuad(s, step, i, w, ones, face, type);
+						else if (face == 1)
+							CreateQuad(s + 1, step, i, w, ones, face, type);
+						else if (face == 2)
+							CreateQuad(i, s, step, w, ones, face, type);
+						else if (face == 3)
+							CreateQuad(i, s + 1, step, w, ones, face, type);
+						else if (face == 4)
+							CreateQuad(i, step, s, w, ones, face, type);
+						else // face == 5
+							CreateQuad(i, step, s + 1, w, ones, face, type);
+
+						step += ones;
 					}
-
-					if (face == 0)
-						CreateQuad(s, step, i, w, ones, face, 0);
-					else if (face == 1)
-						CreateQuad(s + 1, step, i, w, ones, face, 0);
-					else if (face == 2)
-						CreateQuad(i, s, step, w, ones, face, 0);
-					else if (face == 3)
-						CreateQuad(i, s + 1, step, w, ones, face, 0);
-					else if (face == 4)
-						CreateQuad(i, step, s, w, ones, face, 0);
-					else // face == 5
-						CreateQuad(i, step, s + 1, w, ones, face, 0);
-
-					step += ones;
 				}
 			}
 		}
 	}
+
 
 
 	// 5. make GPU buffer from CPU buffer

--- a/voxen/Chunk.h
+++ b/voxen/Chunk.h
@@ -11,7 +11,6 @@
 using namespace Microsoft::WRL; 
 using namespace DirectX::SimpleMath;
 
-
 class Chunk {
 
 public:
@@ -28,6 +27,11 @@ public:
 
 	inline Vector3 GetPosition() { return m_position; }
 	inline void SetPosition(Vector3 position) { m_position = position; }
+
+	static const int CHUNK_SIZE = 32;
+	static const int CHUNK_SIZE2 = CHUNK_SIZE * CHUNK_SIZE;
+	static const int CHUNK_SIZE_P = CHUNK_SIZE + 2;
+	static const int CHUNK_SIZE_P2 = CHUNK_SIZE_P * CHUNK_SIZE_P;
 
 private:
 	void CreateQuad(int x, int y, int z, int merged, int length, int face, int type);

--- a/voxen/ChunkManager.cpp
+++ b/voxen/ChunkManager.cpp
@@ -56,9 +56,9 @@ void ChunkManager::UpdateChunkList(Vector3 cameraChunkPos)
 	for (int i = 0; i < MAX_HEIGHT_CHUNK_COUNT; ++i) {
 		for (int j = 0; j < CHUNK_COUNT; ++j) {
 			for (int k = 0; k < CHUNK_COUNT; ++k) {
-				int y = CHUNK_SIZE * i;
-				int x = (int)cameraChunkPos.x + CHUNK_SIZE * (j - CHUNK_COUNT / 2);
-				int z = (int)cameraChunkPos.z + CHUNK_SIZE * (k - CHUNK_COUNT / 2);
+				int y = Chunk::CHUNK_SIZE * i;
+				int x = (int)cameraChunkPos.x + Chunk::CHUNK_SIZE * (j - CHUNK_COUNT / 2);
+				int z = (int)cameraChunkPos.z + Chunk::CHUNK_SIZE * (k - CHUNK_COUNT / 2);
 
 				if (m_chunkMap.find(std::make_tuple(x, y, z)) == m_chunkMap.end()) { // loading
 					Chunk* chunk = GetChunkFromPool();
@@ -86,18 +86,14 @@ void ChunkManager::UpdateChunkList(Vector3 cameraChunkPos)
 
 void ChunkManager::UpdateLoadChunks()
 {
-	for (auto it = m_loadFutures.begin(); it != m_loadFutures.end();) {
-		if (it->wait_for(std::chrono::seconds(0)) == std::future_status::ready)
-			it = m_loadFutures.erase(it);
-		else
-			++it;
-	}
+	int loadCount = 0;
 
-	while (!m_loadChunkList.empty() && m_loadFutures.size() < MAX_ASYNC_LOAD_COUNT) {
+	while (!m_loadChunkList.empty() && loadCount < MAX_ASYNC_LOAD_COUNT) {
 		Chunk* chunk = m_loadChunkList.back();
 		m_loadChunkList.pop_back();
 
-		m_loadFutures.push_back(std::async(std::launch::async, &Chunk::Initialize, chunk));
+		chunk->Initialize();
+		loadCount++;
 	}
 }
 

--- a/voxen/ChunkManager.h
+++ b/voxen/ChunkManager.h
@@ -20,6 +20,12 @@ public:
 	void Update(Camera& camera);
 	void Render(Camera& camera);
 
+	// Chunk Manager
+	static const int CHUNK_COUNT = 21;
+	static const int MAX_HEIGHT = 256;
+	static const int MAX_HEIGHT_CHUNK_COUNT = MAX_HEIGHT / Chunk::CHUNK_SIZE;
+	static const int MAX_ASYNC_LOAD_COUNT = 4;
+
 private:
 	void UpdateChunkList(Vector3 cameraChunkPos);
 	void UpdateLoadChunks();
@@ -34,6 +40,4 @@ private:
 	std::map<std::tuple<int, int, int>, Chunk*> m_chunkMap;
 	std::vector<Chunk*> m_loadChunkList;
 	std::vector<Chunk*> m_unloadChunkList;
-
-	std::vector<std::future<bool>> m_loadFutures;
 };

--- a/voxen/Graphics.cpp
+++ b/voxen/Graphics.cpp
@@ -193,7 +193,7 @@ bool Graphics::InitShaderResourceBuffers()
 {
 	if (!DXUtils::CreateTextureFromFile(
 			atlasMapBuffer, atlasMapSRV, "../assets/blender_uv_grid_2k.png")) {
-		std::cout << "failed create texture from atlas file" << std::endl;
+		std::cout << "failed create texture from a file" << std::endl;
 		return false;
 	}
 

--- a/voxen/Structure.h
+++ b/voxen/Structure.h
@@ -4,19 +4,6 @@
 
 using namespace DirectX::SimpleMath;
 
-// Chunk
-static const int CHUNK_SIZE = 32;
-static const int CHUNK_SIZE2 = CHUNK_SIZE * CHUNK_SIZE;
-static const int CHUNK_SIZE_P = CHUNK_SIZE + 2;
-static const int CHUNK_SIZE_P2 = CHUNK_SIZE_P * CHUNK_SIZE_P;
-
-// Chunk Manager
-static const int CHUNK_COUNT = 21;
-static const int MAX_HEIGHT = 256;
-static const int MAX_HEIGHT_CHUNK_COUNT = MAX_HEIGHT / CHUNK_SIZE;
-
-static const int MAX_ASYNC_LOAD_COUNT = 4;
-
 typedef uint32_t VoxelVertex;
 
 struct SkyboxVertex {

--- a/voxen/Utils.h
+++ b/voxen/Utils.h
@@ -19,9 +19,9 @@ public:
 		int floorY = (int)floor(pos.y);
 		int floorZ = (int)floor(pos.z);
 
-		int modX = ((floorX % CHUNK_SIZE) + CHUNK_SIZE) % CHUNK_SIZE;
-		int modY = ((floorY % CHUNK_SIZE) + CHUNK_SIZE) % CHUNK_SIZE;
-		int modZ = ((floorZ % CHUNK_SIZE) + CHUNK_SIZE) % CHUNK_SIZE;
+		int modX = ((floorX % Chunk::CHUNK_SIZE) + Chunk::CHUNK_SIZE) % Chunk::CHUNK_SIZE;
+		int modY = ((floorY % Chunk::CHUNK_SIZE) + Chunk::CHUNK_SIZE) % Chunk::CHUNK_SIZE;
+		int modZ = ((floorZ % Chunk::CHUNK_SIZE) + Chunk::CHUNK_SIZE) % Chunk::CHUNK_SIZE;
 
 		return Vector3((float)(floorX - modX), (float)(floorY - modY), (float)(floorZ - modZ));
 	}


### PR DESCRIPTION
## 한 일
- 블록 타입 고려 Greedy Meshing
 -> Chunk 내부의 타입만 반복하여 데이터를 구성 후 Greedy Meshing

close #28 