### PR TITLE
REFACT: 노이즈 범위 수정, Cloud, Sky Shader 최저 고도 수정

### DIFF
--- a/voxen/Cloud.cpp
+++ b/voxen/Cloud.cpp
@@ -31,7 +31,7 @@ bool Cloud::Initialize(Vector3 cameraPosition)
 				(float)j / CLOUD_DATA_MAP_SIZE, CLOUD_DATA_MAP_SIZE * 0.125f, 3);
 			float noise2 = Utils::PerlinFbm((float)i / CLOUD_DATA_MAP_SIZE,
 				(float)j / CLOUD_DATA_MAP_SIZE, CLOUD_DATA_MAP_SIZE * 0.5f, 1);
-			m_dataMap[i][j] = noise1 > 0.2f || noise2 > 0.5f;
+			m_dataMap[i][j] = noise1 > 0.2f || noise2 > 0.45f;
 		}
 	}
 

--- a/voxen/CloudPS.hlsl
+++ b/voxen/CloudPS.hlsl
@@ -87,7 +87,7 @@ float4 main(vsOutput input) : SV_TARGET
     
     float sunAltitude = sin(sunDir.y);
     float dayAltitude = PI / 12.0;
-    float nightAltitude = -PI * (1.7 / 6.0);
+    float nightAltitude = -PI * 0.5 * (1.7 / 6.0);
     float maxHorizonAltitude = -PI / 24.0;
     if (dayAltitude < sunAltitude)
     {
@@ -101,7 +101,7 @@ float4 main(vsOutput input) : SV_TARGET
     {
         color *= lerp(float3(0.04, 0.05, 0.09), horizonColor, smoothstep(nightAltitude, maxHorizonAltitude, sunAltitude));
     }
-    else
+    else // nightAltitude
     {
         color *= float3(0.04, 0.05, 0.09);
     }

--- a/voxen/SkyboxPS.hlsl
+++ b/voxen/SkyboxPS.hlsl
@@ -109,7 +109,7 @@ float4 main(vsOutput input) : SV_TARGET
     float3 posDir = normalize(input.posWorld);
     
     float sunAltitude = sin(sunDir.y);
-    float showSectionAltitude = -PI / 6.0;
+    float showSectionAltitude = -PI * 0.5 * (1.7 / 6.0);
     
     // sun
     float maxSunSize = 220.0f;


### PR DESCRIPTION
close #38 

- 구름 노이즈 범위 0.5f -> 0.45f 로 수정
- 최저 고도 -PI * (1.7 / 6.0)에서 -PI * 0.5 * (1.7 / 6.0) 로 수정