### PR TITLE
82 shadow testing

### DIFF
--- a/voxen/App.cpp
+++ b/voxen/App.cpp
@@ -177,6 +177,7 @@ void App::Render()
 	Graphics::context->PSSetConstantBuffers(
 		7, (UINT)ppConstantBuffers.size(), ppConstantBuffers.data());
 	
+	// 0. Shadow Map
 	{
         RenderShadowMap();
     }
@@ -570,7 +571,7 @@ void App::RenderWaterPlane()
 
 void App::RenderShadowMap()
 {
-	Graphics::context->RSSetViewports(3, m_light.m_shadowViewPorts);
+	Graphics::context->RSSetViewports(Light::CASCADE_NUM, m_light.m_shadowViewPorts);
 
 	Graphics::context->OMSetRenderTargets(0, NULL, Graphics::shadowDSV.Get());
 	Graphics::context->ClearDepthStencilView(Graphics::shadowDSV.Get(), D3D11_CLEAR_DEPTH, 1.0f, 0);

--- a/voxen/App.cpp
+++ b/voxen/App.cpp
@@ -299,7 +299,7 @@ bool App::InitGUI()
 
 bool App::InitScene()
 {
-	if (!m_camera.Initialize(Vector3(0.0f, 128.0f, -128.0f)))
+	if (!m_camera.Initialize(Vector3(128.0f, 128.0f, 128.0f)))
 		return false;
 
 	if (!ChunkManager::GetInstance()->Initialize(m_camera.GetChunkPosition()))

--- a/voxen/App.cpp
+++ b/voxen/App.cpp
@@ -208,7 +208,7 @@ void App::Render()
 		else {
 			//RenderMirrorWorld();
 			//RenderWaterPlane();
-			//RenderFogFilter();
+			RenderFogFilter();
 			RenderSkybox();
 			RenderCloud();
 		}

--- a/voxen/App.cpp
+++ b/voxen/App.cpp
@@ -184,8 +184,8 @@ void App::Render()
     // 1. Deferred Render Pass
     {
         FillGBuffer();
-        //MaskMSAAEdge();
-        //RenderSSAO();
+        MaskMSAAEdge();
+        RenderSSAO();
         ShadingBasic();
     }
 

--- a/voxen/App.cpp
+++ b/voxen/App.cpp
@@ -299,7 +299,7 @@ bool App::InitGUI()
 
 bool App::InitScene()
 {
-	if (!m_camera.Initialize(Vector3(128.0f, 128.0f, 128.0f)))
+	if (!m_camera.Initialize(Vector3(0.0f, 128.0f, -128.0f)))
 		return false;
 
 	if (!ChunkManager::GetInstance()->Initialize(m_camera.GetChunkPosition()))

--- a/voxen/App.cpp
+++ b/voxen/App.cpp
@@ -123,6 +123,8 @@ void App::Run()
 				Terrain::GetErosion(m_camera.GetPosition().x, m_camera.GetPosition().z),
 				Terrain::GetPeaksValley(m_camera.GetPosition().x, m_camera.GetPosition().z));
 
+			ImGui::SliderFloat("bias", &m_camera.m_constantData.dummy.y, 0.0f, 0.1f, "%.10f");
+
 			ImGui::End();
 			ImGui::Render(); // 렌더링할 것들 기록 끝
 
@@ -139,8 +141,8 @@ void App::Run()
 void App::Update(float dt)
 {
 	static float acc = 0.0f;
-
-	m_camera.Update(dt, m_keyPressed, m_mouseNdcX, m_mouseNdcY);
+	if (!m_keyPressed['T'])
+		m_camera.Update(dt, m_keyPressed, m_mouseNdcX, m_mouseNdcY);
 
 	m_postEffect.Update(dt, m_camera.IsUnderWater(), m_light.GetRadianceWeight());
 	ChunkManager::GetInstance()->Update(dt, m_camera, m_light);
@@ -198,14 +200,14 @@ void App::Render()
 	// 3. Forward Render Pass MSAA
 	{
 		if (m_camera.IsUnderWater()) {
-			RenderFogFilter();
+			//RenderFogFilter();
 			RenderSkybox();
 			RenderCloud();
 			RenderWaterPlane();
 		}
 		else {
-			RenderMirrorWorld();
-			RenderWaterPlane();
+			//RenderMirrorWorld();
+			//RenderWaterPlane();
 			//RenderFogFilter();
 			RenderSkybox();
 			RenderCloud();

--- a/voxen/App.cpp
+++ b/voxen/App.cpp
@@ -418,9 +418,8 @@ void App::ShadingBasic()
 	ppSRVs.push_back(Graphics::positionSRV.Get());
 	ppSRVs.push_back(Graphics::albedoSRV.Get());
 	ppSRVs.push_back(Graphics::ssaoSRV.Get());
-	ppSRVs.push_back(Graphics::shadowSRV.Get());
+	
 	Graphics::context->PSSetShaderResources(0, (UINT)ppSRVs.size(), ppSRVs.data());
-
 	Graphics::context->PSSetShaderResources(11, 1, Graphics::shadowSRV.GetAddressOf());
 
 	Graphics::SetPipelineStates(Graphics::shadingBasicPSO);
@@ -428,6 +427,11 @@ void App::ShadingBasic()
 
 	Graphics::SetPipelineStates(Graphics::shadingBasicEdgePSO);
 	m_postEffect.Render();
+
+	ID3D11ShaderResourceView* nullSRV[] = {
+		0,
+	};
+	Graphics::context->PSSetShaderResources(11, 1, nullSRV);
 }
 
 void App::ConvertToMSAA()
@@ -580,6 +584,7 @@ void App::RenderShadowMap()
 
 	Graphics::context->GSSetConstantBuffers(0, 1, m_light.m_shadowConstantBuffer.GetAddressOf());
 
+	Graphics::SetPipelineStates(Graphics::basicShadowPSO);
 	ChunkManager::GetInstance()->RenderShadowMap();
 
 	Graphics::context->RSSetViewports(1, &Graphics::basicViewport);

--- a/voxen/App.cpp
+++ b/voxen/App.cpp
@@ -200,14 +200,14 @@ void App::Render()
 	// 3. Forward Render Pass MSAA
 	{
 		if (m_camera.IsUnderWater()) {
-			//RenderFogFilter();
+			RenderFogFilter();
 			RenderSkybox();
 			RenderCloud();
 			RenderWaterPlane();
 		}
 		else {
-			//RenderMirrorWorld();
-			//RenderWaterPlane();
+			RenderMirrorWorld();
+			RenderWaterPlane();
 			RenderFogFilter();
 			RenderSkybox();
 			RenderCloud();

--- a/voxen/App.h
+++ b/voxen/App.h
@@ -25,8 +25,8 @@ public:
 
 	static const UINT WIDTH = 1920;
 	static const UINT HEIGHT = 1080;
-	static const UINT SHADOW_WIDTH = 3840;
-	static const UINT SHADOW_HEIGHT = 2048;
+	static const UINT SHADOW_WIDTH = 1920;
+	static const UINT SHADOW_HEIGHT = 1024;
 	static const UINT MIRROR_WIDTH = WIDTH / 2;
 	static const UINT MIRROR_HEIGHT = HEIGHT / 2;
 

--- a/voxen/App.h
+++ b/voxen/App.h
@@ -26,7 +26,7 @@ public:
 	static const UINT WIDTH = 1920;
 	static const UINT HEIGHT = 1080;
 	static const UINT SHADOW_WIDTH = 3840;
-	static const UINT SHADOW_HEIGHT = 1536;
+	static const UINT SHADOW_HEIGHT = 2048;
 	static const UINT MIRROR_WIDTH = WIDTH / 2;
 	static const UINT MIRROR_HEIGHT = HEIGHT / 2;
 

--- a/voxen/App.h
+++ b/voxen/App.h
@@ -25,8 +25,8 @@ public:
 
 	static const UINT WIDTH = 1920;
 	static const UINT HEIGHT = 1080;
-	static const UINT SHADOW_WIDTH = 3840;
-	static const UINT SHADOW_HEIGHT = 2048;
+	static const UINT SHADOW_WIDTH = 3072;
+	static const UINT SHADOW_HEIGHT = 1024;
 	static const UINT MIRROR_WIDTH = WIDTH / 2;
 	static const UINT MIRROR_HEIGHT = HEIGHT / 2;
 

--- a/voxen/App.h
+++ b/voxen/App.h
@@ -25,8 +25,8 @@ public:
 
 	static const UINT WIDTH = 1920;
 	static const UINT HEIGHT = 1080;
-	static const UINT SHADOW_WIDTH = 1920;
-	static const UINT SHADOW_HEIGHT = 1024;
+	static const UINT SHADOW_WIDTH = 3840;
+	static const UINT SHADOW_HEIGHT = 2048;
 	static const UINT MIRROR_WIDTH = WIDTH / 2;
 	static const UINT MIRROR_HEIGHT = HEIGHT / 2;
 

--- a/voxen/BasicPS.hlsl
+++ b/voxen/BasicPS.hlsl
@@ -7,8 +7,8 @@ Texture2D mirrorDepthTex : register(t2);
 struct psInput
 {
     float4 posProj : SV_POSITION;
-    float3 posWorld : POSITION;
-    float3 normal : NORMAL;
+    sample float3 posWorld : POSITION;
+    sample float3 normal : NORMAL;
     sample float2 texcoord : TEXCOORD;
     uint type : TYPE;
 };

--- a/voxen/BasicShadowGS.hlsl
+++ b/voxen/BasicShadowGS.hlsl
@@ -1,8 +1,6 @@
-cbuffer LightConstantBuffer : register(b0)
+cbuffer ShadowConstantBuffer : register(b0)
 {
-    Matrix viewProj[3];
-    float4 topLX;
-    float4 viewPortW;
+    Matrix viewProj[4];
 }
 
 struct vsOutput
@@ -16,19 +14,19 @@ struct gsOutput
     uint VPIndex : SV_ViewportArrayIndex;
 };
 
-[maxvertexcount(9)]
+[maxvertexcount(12)]
 void main(triangle vsOutput input[3], inout TriangleStream<gsOutput> output)
 {
     gsOutput element;
     
-    for (int face = 0; face < 3; ++face)
+    for (int cascade = 0; cascade < 4; ++cascade)
     {
-        element.VPIndex = face;
+        element.VPIndex = cascade;
         
         for (int i = 0; i < 3; ++i)
         {
             float4 position = float4(input[i].posWorld.xyz, 1.0);
-            element.pos = mul(position, viewProj[face]);
+            element.pos = mul(position, viewProj[cascade]);
             output.Append(element);
         }
         output.RestartStrip();

--- a/voxen/BasicShadowGS.hlsl
+++ b/voxen/BasicShadowGS.hlsl
@@ -1,6 +1,6 @@
 cbuffer ShadowConstantBuffer : register(b0)
 {
-    Matrix viewProj[4];
+    Matrix viewProj[3];
 }
 
 struct vsOutput
@@ -14,12 +14,12 @@ struct gsOutput
     uint VPIndex : SV_ViewportArrayIndex;
 };
 
-[maxvertexcount(12)]
+[maxvertexcount(9)]
 void main(triangle vsOutput input[3], inout TriangleStream<gsOutput> output)
 {
     gsOutput element;
     
-    for (int cascade = 0; cascade < 4; ++cascade)
+    for (int cascade = 0; cascade < 3; ++cascade)
     {
         element.VPIndex = cascade;
         

--- a/voxen/BasicVS.hlsl
+++ b/voxen/BasicVS.hlsl
@@ -8,8 +8,8 @@ cbuffer ChunkConstantBuffer : register(b0)
 struct vsOutput
 {
     float4 posProj : SV_POSITION;
-    float3 posWorld : POSITION;
-    float3 normal : NORMAL;
+    sample float3 posWorld : POSITION;
+    sample float3 normal : NORMAL;
     sample float2 texcoord : TEXCOORD;
     uint type : TYPE;
 };

--- a/voxen/Camera.cpp
+++ b/voxen/Camera.cpp
@@ -56,7 +56,8 @@ void Camera::Update(float dt, bool keyPressed[256], float mouseX, float mouseY)
 	else {
 		m_constantData.dummy.x = 1.0f;
 		m_isOnConstantDirtyFlag = true;
-	}/////////////////////////////
+	}
+	/////////////////////////////
 
 	if (m_isOnConstantDirtyFlag) {
 		m_constantData.view = GetViewMatrix().Transpose();

--- a/voxen/Camera.cpp
+++ b/voxen/Camera.cpp
@@ -57,6 +57,14 @@ void Camera::Update(float dt, bool keyPressed[256], float mouseX, float mouseY)
 		m_constantData.dummy.x = 1.0f;
 		m_isOnConstantDirtyFlag = true;
 	}
+	if (keyPressed['Q']) {
+		m_constantData.dummy.z = 0.0f;
+		m_isOnConstantDirtyFlag = true;
+	}
+	else {
+		m_constantData.dummy.z = 1.0f;
+		m_isOnConstantDirtyFlag = true;
+	}
 	/////////////////////////////
 
 	if (m_isOnConstantDirtyFlag) {

--- a/voxen/Camera.h
+++ b/voxen/Camera.h
@@ -11,7 +11,7 @@ using namespace DirectX::SimpleMath;
 
 class Camera {
 public:
-	static const int MAX_RENDER_DISTANCE = 200;
+	static const int MAX_RENDER_DISTANCE = 260;
 	static const int LOD_RENDER_DISTANCE = 160;
 
 	Camera();
@@ -39,6 +39,8 @@ public:
 	bool m_isOnConstantDirtyFlag;
 	bool m_isOnChunkDirtyFlag;
 	
+	CameraConstantData m_constantData;
+
 private:
 	void UpdatePosition(bool keyPressed[256], float dt);
 	void UpdateViewDirection(float mouseX, float mouseY);
@@ -67,7 +69,7 @@ private:
 
 	bool m_isUnderWater;
 
-	CameraConstantData m_constantData;
+	//CameraConstantData m_constantData;
 
 	Vector3 lookTo[6] = {
 		Vector3(1.0f, 0.0f, 0.0f),

--- a/voxen/Chunk.cpp
+++ b/voxen/Chunk.cpp
@@ -112,10 +112,10 @@ void Chunk::InitChunkData()
 
 				m_blocks[x][y][z].SetType(transparencyType);
 				if (worldY <= baseLevel) {
-					m_blocks[x][y][z].SetType(2);
+					m_blocks[x][y][z].SetType(6);
 
 					if (d1 * d1 + d2 * d2 <= 0.004f) {
-						//m_blocks[x][y][z].SetType(transparencyType);
+						m_blocks[x][y][z].SetType(transparencyType);
 					}
 				}
 			}

--- a/voxen/Chunk.cpp
+++ b/voxen/Chunk.cpp
@@ -112,7 +112,7 @@ void Chunk::InitChunkData()
 
 				m_blocks[x][y][z].SetType(transparencyType);
 				if (worldY <= baseLevel) {
-					m_blocks[x][y][z].SetType(3);
+					m_blocks[x][y][z].SetType(2);
 
 					if (d1 * d1 + d2 * d2 <= 0.004f) {
 						//m_blocks[x][y][z].SetType(transparencyType);

--- a/voxen/Chunk.cpp
+++ b/voxen/Chunk.cpp
@@ -112,9 +112,10 @@ void Chunk::InitChunkData()
 
 				m_blocks[x][y][z].SetType(transparencyType);
 				if (worldY <= baseLevel) {
-					m_blocks[x][y][z].SetType(2);
+					m_blocks[x][y][z].SetType(3);
+
 					if (d1 * d1 + d2 * d2 <= 0.004f) {
-						m_blocks[x][y][z].SetType(transparencyType);
+						//m_blocks[x][y][z].SetType(transparencyType);
 					}
 				}
 			}

--- a/voxen/Chunk.cpp
+++ b/voxen/Chunk.cpp
@@ -112,7 +112,7 @@ void Chunk::InitChunkData()
 
 				m_blocks[x][y][z].SetType(transparencyType);
 				if (worldY <= baseLevel) {
-					m_blocks[x][y][z].SetType(6);
+					m_blocks[x][y][z].SetType(3);
 
 					if (d1 * d1 + d2 * d2 <= 0.004f) {
 						m_blocks[x][y][z].SetType(transparencyType);

--- a/voxen/ChunkManager.cpp
+++ b/voxen/ChunkManager.cpp
@@ -337,14 +337,18 @@ void ChunkManager::UpdateRenderChunkList(Camera& camera, Light& light)
 			m_renderChunkList.push_back(p.second);
 		}
 
-		if (FrustumCulling(chunkPos, camera, light, false, true)) {
-			m_renderShadowChunkList.push_back(p.second);
+		for (int i = 0; i < Light::CASCADE_NUM; ++i) {
+			if (FrustumCulling(chunkPos, camera, light, false, true, i)) {
+				m_renderShadowChunkList.push_back(p.second);
+				break;
+			}
 		}
 
 		Vector3 mirrorChunkPos = Vector3::Transform(chunkPos, camera.GetMirrorPlaneMatrix());
 		if (FrustumCulling(mirrorChunkPos, camera, light, true, false)) {
 			m_renderMirrorChunkList.push_back(p.second);
 		}
+		
 	}
 }
 
@@ -405,12 +409,12 @@ void ChunkManager::UpdateChunkConstant(float dt)
 }
 
 bool ChunkManager::FrustumCulling(
-	Vector3 position, Camera& camera, Light& light, bool useMirror, bool useShadow)
+	Vector3 position, Camera& camera, Light& light, bool useMirror, bool useShadow, int index)
 {
 	Matrix invMat = (camera.GetViewMatrix() * camera.GetProjectionMatrix()).Invert();
 
 	if (useShadow) {
-		invMat = (light.GetViewMatrix(3) * light.GetProjectionMatrix(3)).Invert();
+		invMat = (light.GetViewMatrix(index) * light.GetProjectionMatrix(index)).Invert();
 	};
 
 	std::vector<Vector3> worldPos = { Vector3::Transform(Vector3(-1.0f, 1.0f, 0.0f), invMat),

--- a/voxen/ChunkManager.cpp
+++ b/voxen/ChunkManager.cpp
@@ -410,7 +410,7 @@ bool ChunkManager::FrustumCulling(
 	Matrix invMat = (camera.GetViewMatrix() * camera.GetProjectionMatrix()).Invert();
 
 	if (useShadow) {
-		invMat = (light.GetViewMatrix(2) * light.GetProjectionMatrix(2)).Invert();
+		invMat = (light.GetViewMatrix(3) * light.GetProjectionMatrix(3)).Invert();
 	};
 
 	std::vector<Vector3> worldPos = { Vector3::Transform(Vector3(-1.0f, 1.0f, 0.0f), invMat),

--- a/voxen/ChunkManager.cpp
+++ b/voxen/ChunkManager.cpp
@@ -214,7 +214,6 @@ void ChunkManager::RenderTransparency()
 
 void ChunkManager::RenderShadowMap()
 {
-	Graphics::SetPipelineStates(Graphics::basicShadowPSO);
 	for (auto& c : m_renderShadowChunkList)
 		RenderLowLodChunk(c);
 }
@@ -336,7 +335,7 @@ void ChunkManager::UpdateRenderChunkList(Camera& camera, Light& light)
 		if (FrustumCulling(chunkPos, camera, light, false, false)) {
 			m_renderChunkList.push_back(p.second);
 		}
-
+		
 		for (int i = 0; i < Light::CASCADE_NUM; ++i) {
 			if (FrustumCulling(chunkPos, camera, light, false, true, i)) {
 				m_renderShadowChunkList.push_back(p.second);
@@ -411,11 +410,14 @@ void ChunkManager::UpdateChunkConstant(float dt)
 bool ChunkManager::FrustumCulling(
 	Vector3 position, Camera& camera, Light& light, bool useMirror, bool useShadow, int index)
 {
-	Matrix invMat = (camera.GetViewMatrix() * camera.GetProjectionMatrix()).Invert();
-
+	Matrix invMat = Matrix();
+	
 	if (useShadow) {
 		invMat = (light.GetViewMatrix(index) * light.GetProjectionMatrix(index)).Invert();
-	};
+	}
+	else {
+		invMat = (camera.GetViewMatrix() * camera.GetProjectionMatrix()).Invert();
+	}
 
 	std::vector<Vector3> worldPos = { Vector3::Transform(Vector3(-1.0f, 1.0f, 0.0f), invMat),
 		Vector3::Transform(Vector3(1.0f, 1.0f, 0.0f), invMat),

--- a/voxen/ChunkManager.cpp
+++ b/voxen/ChunkManager.cpp
@@ -413,7 +413,7 @@ bool ChunkManager::FrustumCulling(
 	Matrix invMat = Matrix();
 	
 	if (useShadow) {
-		invMat = (light.GetViewMatrix(index) * light.GetProjectionMatrix(index)).Invert();
+		invMat = (light.GetViewMatrix() * light.GetProjectionMatrixFromCascade(index)).Invert();
 	}
 	else {
 		invMat = (camera.GetViewMatrix() * camera.GetProjectionMatrix()).Invert();

--- a/voxen/ChunkManager.h
+++ b/voxen/ChunkManager.h
@@ -59,7 +59,7 @@ private:
 	void UpdateChunkConstant(float dt);
 
 	bool FrustumCulling(
-		Vector3 position, Camera& camera, Light& light, bool useMirror, bool useShadow);
+		Vector3 position, Camera& camera, Light& light, bool useMirror, bool useShadow, int index = 0);
 
 	void InitChunkBuffer(Chunk* chunk);
 	

--- a/voxen/CloudPS.hlsl
+++ b/voxen/CloudPS.hlsl
@@ -31,7 +31,7 @@ float4 main(psInput input) : SV_TARGET
     float3 ambientLighting = getAmbientLighting(1.0, albedo, normal);
     
     // direct lighting
-    float3 directLighting = getDirectLighting(normal, input.posWorld, albedo, 0.0, 0.96);
+    float3 directLighting = getDirectLighting(normal, input.posWorld, albedo, 0.0, 0.96, false);
     
     // distance alpha
     float alphaWeight = smoothstep(maxRenderDistance, cloudScale, clamp(distance, maxRenderDistance, cloudScale));

--- a/voxen/Common.hlsli
+++ b/voxen/Common.hlsli
@@ -18,10 +18,10 @@ static const float2 poissonDisk[16] =
 
 SamplerState pointWrapSS : register(s0);
 SamplerState linearWrapSS : register(s1);
-SamplerState linearClampSS : register(s2);
-SamplerState shadowPointSS : register(s3);
+SamplerState pointClampSS : register(s2);
+SamplerState linearClampSS : register(s3);
 SamplerComparisonState shadowCompareSS : register(s4);
-SamplerState pointClampSS : register(s5);
+
 
 Texture2D shadowTex : register(t11);
 
@@ -71,6 +71,8 @@ cbuffer ShadowConstantBuffer : register(b11)
     Matrix shadowViewProj[4];
     float4 topLX;
     float4 viewPortW;
+    float4 frustumW;
+    float4 frustumH;
 }
 
 float3 sRGB2Linear(float3 color)
@@ -178,8 +180,8 @@ float3 getAmbientLighting(float ao, float3 albedo, float3 normal)
     // face ambient
     float faceAmbient = getFaceAmbient(normal);
     
-    if (cameraDummyData.x != 0)
-        return float3(0.0, 0.0, 0.0);
+    if (cameraDummyData.x == 0)
+        return float3(0, 0, 0);
     
     return ao * albedo * ambientColor * faceAmbient * ambientWeight;
 }
@@ -211,61 +213,89 @@ float getRandom(float3 seed, int i)
     return frac(sin(dot_product) * 43758.5453);
 }
 
-float getShadowFactor(float3 posWorld, float3 normal, out float3 color)
+float getShadowFactor(float3 posWorld, float3 normal)
 {
     float width, height, numMips;
     shadowTex.GetDimensions(0, width, height, numMips);
     
-    float dx = 3.0 / width;
-    float dy = 3.0 / height;
+    float topLXOffsets[4] = { topLX.x, topLX.y, topLX.z, topLX.w };
+    float viewPortWidth[4] = { viewPortW.x, viewPortW.y, viewPortW.z, viewPortW.w };
+    float frustumWidth[4] = { frustumW.x, frustumW.y, frustumW.z, frustumW.w };
+    float frustumHeight[4] = { frustumH.x, frustumH.y, frustumH.z, frustumH.w };
     
-    float g_topLX[4] = { topLX.x, topLX.y, topLX.z, topLX.w };
-    float g_viewPortW[4] = { viewPortW.x, viewPortW.y, viewPortW.z, viewPortW.w };
+    // 경계선
+    // CSM간 bias
+    // flickering
     
-    color = radianceColor;
+    float dx = 2.0 / viewPortWidth[0];
+    float dy = 2.0 / viewPortWidth[0];
+    
     for (int i = 0; i < 4; ++i)
     {
         float4 lightProj = mul(float4(posWorld, 1.0), shadowViewProj[i]);
         lightProj.xyz /= lightProj.w;
         
-        if (lightProj.x < -1.0 || lightProj.x > 1.0 || 
-            lightProj.y < -1.0 || lightProj.y > 1.0 || 
+        if (lightProj.x < -1.0 || lightProj.x > 1.0 ||
+            lightProj.y < -1.0 || lightProj.y > 1.0 ||
             lightProj.z < 0.0 || lightProj.z > 1.0)
         {
-            continue;
+            dx *= 0.5;
+            dy *= 0.5;
+                
+            continue ;
         }
         
+        //float bias = 0.0002 + 0.018 * pow(1.0 - max(dot(lightDir, normal), 0.0), 3.0);
+        //bias *= pow(2.0, i);
         float bias = cameraDummyData.y;
-        //if (i == 0)
-            //bias = 0.0001 + 0.0002 * pow((1.0 - dot(normal, lightDir)), 1.5);
-        /*
-        어떻게 두 cascade 사이를 부드럽게 이을 것인가 -> blendWeight를 이용하여 겹치는 부분을 샘플링
-        bias
-        pcf의 문제를 어떻게 해결할 것인가
-        */
-        
-        
-        float depth = lightProj.z - bias;
-        
         float2 lightTexcoord = float2(lightProj.x * 0.5 + 0.5, lightProj.y * -0.5 + 0.5);
+        
         // scaling
-        lightTexcoord.x = (lightTexcoord.x * (g_viewPortW[i] / width)) + (g_topLX[i] / width);
-        lightTexcoord.y = (lightTexcoord.y * (g_viewPortW[i] / height));
+        float2 scaledTexcoord;
+        scaledTexcoord.x = (lightTexcoord.x * (viewPortWidth[i] / width)) + (topLXOffsets[i] / width);
+        scaledTexcoord.y = (lightTexcoord.y * (viewPortWidth[i] / height));
         
         float denom = 1.0;
+        //float percentLit = shadowTex.SampleCmpLevelZero(shadowCompareSS, scaledTexcoord, lightProj.z - bias).r;
         float percentLit = 0.0;
-        [unroll]
-        for (int j = 0; j < 1; ++j)
+        float depth = shadowTex.SampleLevel(linearClampSS, scaledTexcoord, 0.0).r;
+        if (depth < lightProj.z - bias)
         {
-            int index = int(16.0 * getRandom(posWorld, j)) % 16u;
-            float2 texcoord = lightTexcoord.xy; //+ float2(dx, dy) * poissonDisk[index];
-            
-            texcoord.x = clamp(texcoord.x, g_topLX[i] / width, (g_topLX[i] + g_viewPortW[i]) / width);
-            texcoord.y = clamp(texcoord.y, 0.0, g_viewPortW[i] / height);
-                        
-            percentLit += shadowTex.SampleCmpLevelZero(shadowCompareSS, texcoord, depth).r;
+            percentLit = 0.0;
+        }
+        else
+        {
+            percentLit = 1.0;
         }
         
+        [loop]
+        for (int j = 0; j < 16; ++j)
+        {
+            int index = int(16.0 * getRandom(posWorld, j)) % 16u;
+            float2 texcoord = scaledTexcoord.xy + float2(dx, dy) * poissonDisk[index];
+            
+            if (texcoord.x < topLXOffsets[i] / width || texcoord.x > (topLXOffsets[i] + viewPortWidth[i]) / width ||
+                texcoord.y < 0.0 || texcoord.y > viewPortWidth[i] / height)
+            {
+                continue;
+            }
+            else
+            {
+                //percentLit += shadowTex.SampleCmpLevelZero(shadowCompareSS, texcoord, lightProj.z - bias).r;
+                
+                depth = shadowTex.SampleLevel(linearClampSS, texcoord, 0.0).r;
+                if (depth < lightProj.z - bias)
+                {
+                    percentLit += 0.0;
+                }
+                else
+                {
+                    percentLit += 1.0;
+                }
+                
+                denom += 1.0;
+            }
+        }
         return (percentLit / denom);
     }
     return 1.0;
@@ -290,13 +320,11 @@ float3 getDirectLighting(float3 normal, float3 position, float3 albedo, float me
     float3 kd = lerp(float3(1, 1, 1) - F, float3(0, 0, 0), metallic);
     float3 diffuseBRDF = kd * albedo;
     
-    float3 color = float3(1, 1, 1);
     float shadowFactor = 1.0;
     if (useShadow)
-        shadowFactor = getShadowFactor(position, normal, color);
+        shadowFactor = getShadowFactor(position, normal);
     
-    //float3 radiance = radianceColor * shadowFactor;
-    float3 radiance = color * shadowFactor;
+    float3 radiance = radianceWeight * radianceColor * shadowFactor;
     
     return (diffuseBRDF + specularBRDF) * radiance * NdotI;
 }

--- a/voxen/Common.hlsli
+++ b/voxen/Common.hlsli
@@ -250,6 +250,16 @@ float getShadowFactor(float3 posWorld)
             texcoord = clamp(texcoord, 0.0, 1.0);
             percentLit += shadowTex.SampleCmpLevelZero(shadowCompareSS, texcoord, depth).r;
         }
+        ////////////////
+        if (i == 0)
+            return 0.133;
+        else if (i == 1)
+            return 0.263;
+        else if (i == 2)
+            return 0.393;
+        else if (i == 3)
+            return 0.553;
+        ////////////////
         return percentLit / denom;
     }
     return 1.0;
@@ -276,6 +286,15 @@ float3 getDirectLighting(float3 normal, float3 position, float3 albedo, float me
     
     // todo
     float shadowFactor = getShadowFactor(position);
+    if (shadowFactor == 0.133)
+        return float3(1, 0, 0);
+    else if (shadowFactor == 0.263)
+        return float3(0, 1, 0);
+    else if (shadowFactor == 0.393)
+        return float3(0, 0, 1);
+    else if (shadowFactor == 0.553)
+        return float3(1, 1, 0);
+    
     shadowFactor = pow(shadowFactor, 10.0);
     
     float3 radiance = radianceColor * shadowFactor; // radiance °ª ¼öÁ¤\

--- a/voxen/Common.hlsli
+++ b/voxen/Common.hlsli
@@ -147,7 +147,6 @@ float getFaceAmbient(float3 normal)
 
 float3 getAmbientLighting(float ao, float3 albedo, float3 normal)
 {
-    ao = 1.0;
     // skycolor ambient (envMap을 가정함)
     float sunAniso = max(dot(lightDir, eyeDir), 0.0);
     float3 eyeHorizonColor = lerp(normalHorizonColor, sunHorizonColor, sunAniso);
@@ -157,33 +156,35 @@ float3 getAmbientLighting(float ao, float3 albedo, float3 normal)
     float dayAltitude = PI / 12.0;
     float maxHorizonAltitude = -PI / 24.0;
     if (sunAltitude <= dayAltitude)
-    {        
+    {
         float w = smoothstep(maxHorizonAltitude, dayAltitude, sunAltitude);
         ambientColor = lerp(eyeHorizonColor, ambientColor, w);
     }
     
+    float3 ambientWeight = 0.5;
+    
     // face ambient
     float faceAmbient = getFaceAmbient(normal);
     
-    if (cameraDummyData.x == 0)
+    if (cameraDummyData.x != 0)
         return float3(0.0, 0.0, 0.0);
     
-    return ao * albedo * ambientColor * faceAmbient;
+    return ao * albedo * ambientColor * faceAmbient * ambientWeight;
 }
 
-float3 SchlickFresnel(float3 F0, float NdotH)
+float3 schlickFresnel(float3 F0, float NdotH)
 {
     return F0 + (1 - F0) * pow(2, (-5.55473 * (NdotH) - 6.98316) * NdotH);
 }
 
-float NdfGGX(float NdotH, float roughness)
+float ndfGGX(float NdotH, float roughness)
 {
     float alpha = roughness * roughness;
     float alpha2 = alpha * alpha;
     return alpha2 / (3.141592 * pow(NdotH * NdotH * (alpha2 - 1) + 1, 2));
 }
 
-float SchlickGGX(float NdotI, float NdotO, float roughness)
+float schlickGGX(float NdotI, float NdotO, float roughness)
 {
     float k = (roughness + 1) * (roughness + 1) / 8;
     float gl = NdotI / (NdotI * (1 - k) + k);
@@ -191,14 +192,23 @@ float SchlickGGX(float NdotI, float NdotO, float roughness)
     return gl * gv;
 }
 
-float getShadowFactor(float3 posWorld)
+float getRandom(float3 seed, int i)
+{
+    float4 seed4 = float4(seed, i);
+    float dot_product = dot(seed4, float4(12.9898, 78.233, 45.164, 94.673));
+    return frac(sin(dot_product) * 43758.5453);
+}
+
+float getShadowFactor(float3 posWorld, float3 normal)
 {
     float width, height, numMips;
     shadowTex.GetDimensions(0, width, height, numMips);
     
+    float dx = 3.0 / width;
+    float dy = 3.0 / height;
+    
     float g_topLX[4] = { topLX.x, topLX.y, topLX.z, topLX.w };
     float g_viewPortW[4] = { viewPortW.x, viewPortW.y, viewPortW.z, viewPortW.w };
-    float biasA[4] = { 0.002, 0.003, 0.002, 0.002 };
     
     for (int i = 0; i < 4; ++i)
     {
@@ -213,7 +223,13 @@ float getShadowFactor(float3 posWorld)
             continue;
         }
         
-        float bias = biasA[i];
+        float bias = cameraDummyData.y;
+        //if (i == 0)
+            //bias = 0.0001 + 0.0002 * pow((1.0 - dot(normal, lightDir)), 1.5);
+        /*
+        bias 수정
+        겹칠 때? 서로 다른 건?
+        */
         
         float depth = shadowPos.z - bias;
         if (depth < 0.0 || depth > 1.0)
@@ -221,10 +237,6 @@ float getShadowFactor(float3 posWorld)
             continue;
         }
         
-        float dx = 3.0 / width;
-        float dy = 3.0 / height;
-
-        float percentLit = 0.0;
         const float2 poissonDisk[16] =
         {
             float2(-0.94201624, -0.39906216), float2(0.94558609, -0.76890725),
@@ -236,36 +248,31 @@ float getShadowFactor(float3 posWorld)
             float2(-0.24188840, 0.99706507), float2(-0.81409955, 0.91437590),
             float2(0.19984126, 0.78641367), float2(0.14383161, -0.14100790)
         };
-
         
         shadowPos.x = (shadowPos.x * (g_viewPortW[i] / width)) + (g_topLX[i] / width);
         shadowPos.y = (shadowPos.y * (g_viewPortW[i] / height));
         
-        float2 texcoord;
         float denom = 16.0;
+        float percentLit = 0.0;
         [unroll]
         for (int j = 0; j < 16; ++j)
         {
-            texcoord = shadowPos.xy + float2(dx, dy) * poissonDisk[j];
-            texcoord = clamp(texcoord, 0.0, 1.0);
+            int index = int(16.0 * getRandom(posWorld, j)) % 16u;
+            float2 texcoord = shadowPos.xy + float2(dx, dy) * poissonDisk[index];
+            
+            texcoord.x = clamp(texcoord.x, g_topLX[i] / width, (g_topLX[i] + g_viewPortW[i]) / width);
+            texcoord.y = clamp(texcoord.y, 0.0, g_viewPortW[i] / height);
+            
             percentLit += shadowTex.SampleCmpLevelZero(shadowCompareSS, texcoord, depth).r;
         }
-        ////////////////
-        if (i == 0)
-            return 0.133;
-        else if (i == 1)
-            return 0.263;
-        else if (i == 2)
-            return 0.393;
-        else if (i == 3)
-            return 0.553;
-        ////////////////
+        
         return percentLit / denom;
     }
+    
     return 1.0;
 }
 
-float3 getDirectLighting(float3 normal, float3 position, float3 albedo, float metallic, float roughness)
+float3 getDirectLighting(float3 normal, float3 position, float3 albedo, float metallic, float roughness, bool useShadow)
 {
     float3 pixelToEye = normalize(eyePos - position);
     float3 halfway = normalize(pixelToEye + lightDir);
@@ -276,28 +283,19 @@ float3 getDirectLighting(float3 normal, float3 position, float3 albedo, float me
     
     const float3 Fdielectric = 0.04; // 비금속(Dielectric) 재질의 F0
     float3 F0 = lerp(Fdielectric, albedo, metallic);
-    float3 F = SchlickFresnel(F0, max(0.0, dot(halfway, pixelToEye))); // HoV
-    float D = NdfGGX(NdotH, roughness);
-    float3 G = SchlickGGX(NdotI, NdotO, roughness);
-    float3 specularBRDF = (F * D * G) / max(1e-5, 4.0 * NdotI * NdotO);  
+    float3 F = schlickFresnel(F0, max(0.0, dot(halfway, pixelToEye))); // HoV
+    float D = ndfGGX(NdotH, roughness);
+    float3 G = schlickGGX(NdotI, NdotO, roughness);
+    float3 specularBRDF = (F * D * G) / max(1e-5, 4.0 * NdotI * NdotO);
 
     float3 kd = lerp(float3(1, 1, 1) - F, float3(0, 0, 0), metallic);
     float3 diffuseBRDF = kd * albedo;
     
-    // todo
-    float shadowFactor = getShadowFactor(position);
-    if (shadowFactor == 0.133)
-        return float3(1, 0, 0);
-    else if (shadowFactor == 0.263)
-        return float3(0, 1, 0);
-    else if (shadowFactor == 0.393)
-        return float3(0, 0, 1);
-    else if (shadowFactor == 0.553)
-        return float3(1, 1, 0);
+    float shadowFactor = 1.0;
+    if (useShadow)
+        shadowFactor = getShadowFactor(position, normal);
     
-    shadowFactor = pow(shadowFactor, 10.0);
-    
-    float3 radiance = radianceColor * shadowFactor; // radiance 값 수정\
+    float3 radiance = radianceColor * shadowFactor;
     
     return (diffuseBRDF + specularBRDF) * radiance * NdotI;
 }

--- a/voxen/Graphics.cpp
+++ b/voxen/Graphics.cpp
@@ -1079,7 +1079,7 @@ bool Graphics::InitSamplerStates()
 	desc.AddressU = D3D11_TEXTURE_ADDRESS_BORDER;
 	desc.AddressV = D3D11_TEXTURE_ADDRESS_BORDER;
 	desc.AddressW = D3D11_TEXTURE_ADDRESS_BORDER;
-	desc.BorderColor[0] = 100.0f;
+	desc.BorderColor[0] = 1.0f;
 	desc.Filter = D3D11_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT;
 	desc.ComparisonFunc = D3D11_COMPARISON_LESS_EQUAL;
 	ret = Graphics::device->CreateSamplerState(&desc, shadowCompareSS.GetAddressOf());

--- a/voxen/Graphics.cpp
+++ b/voxen/Graphics.cpp
@@ -1068,6 +1068,7 @@ bool Graphics::InitSamplerStates()
 		return false;
 	}
 
+	// linear clamp
 	desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
 	desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
 	desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
@@ -1079,10 +1080,13 @@ bool Graphics::InitSamplerStates()
 
 	// shadowCompareSS
 	desc.Filter = D3D11_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT;
-	desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
-	desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
-	desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
-	desc.ComparisonFunc = D3D11_COMPARISON_LESS_EQUAL;
+	desc.AddressU = D3D11_TEXTURE_ADDRESS_BORDER;
+	desc.AddressV = D3D11_TEXTURE_ADDRESS_BORDER;
+	desc.AddressW = D3D11_TEXTURE_ADDRESS_BORDER;
+	desc.ComparisonFunc = D3D11_COMPARISON_LESS;
+	desc.BorderColor[0] = 0.0f;
+	desc.BorderColor[1] = 0.0f;
+	desc.BorderColor[2] = 0.0f;
 	ret = Graphics::device->CreateSamplerState(&desc, shadowCompareSS.GetAddressOf());
 	if (FAILED(ret)) {
 		std::cout << "failed create shadowCompare SS" << std::endl;

--- a/voxen/Graphics.h
+++ b/voxen/Graphics.h
@@ -65,17 +65,15 @@ namespace Graphics {
 	extern ComPtr<ID3D11RasterizerState> wireRS;
 	extern ComPtr<ID3D11RasterizerState> noneCullRS;
 	extern ComPtr<ID3D11RasterizerState> mirrorRS;
-	extern ComPtr<ID3D11RasterizerState> frontCullRS;
+	extern ComPtr<ID3D11RasterizerState> shadowRS;
 
 	// Sampler State
 	extern ComPtr<ID3D11SamplerState> pointWrapSS;
 	extern ComPtr<ID3D11SamplerState> linearWrapSS;
-	extern ComPtr<ID3D11SamplerState> linearClampSS;
-	extern ComPtr<ID3D11SamplerState> shadowPointSS;
-	extern ComPtr<ID3D11SamplerState> shadowCompareSS;
 	extern ComPtr<ID3D11SamplerState> pointClampSS;
-
-
+	extern ComPtr<ID3D11SamplerState> linearClampSS;
+	extern ComPtr<ID3D11SamplerState> shadowCompareSS;
+	
 
 	// Depth Stencil State
 	extern ComPtr<ID3D11DepthStencilState> basicDSS;

--- a/voxen/ShadingBasicPS.hlsl
+++ b/voxen/ShadingBasicPS.hlsl
@@ -23,7 +23,7 @@ float4 main(psInput input) : SV_TARGET
     albedo /= SAMPLE_COUNT;
     
     float ao = ssaoTex.Sample(pointClampSS, input.texcoord).r;
-    ao = pow(ao, 2.0);
+    ao = pow(ao, 1.5);
     
     // todo
     float metallic = 0.0;
@@ -52,7 +52,7 @@ float4 mainMSAA(psInput input) : SV_TARGET
         float3 albedo = albedoTex.Load(input.posProj.xy, i).rgb; 
         
         float ao = ssaoTex.Sample(pointClampSS, input.texcoord).r;
-        ao = pow(ao, 2.0);
+        ao = pow(ao, 1.5);
         
         // todo
         float metallic = 0.0;

--- a/voxen/ShadingBasicPS.hlsl
+++ b/voxen/ShadingBasicPS.hlsl
@@ -28,7 +28,7 @@ float4 main(psInput input) : SV_TARGET
     float roughness = 0.98;
     
     float3 ambientLighting = getAmbientLighting(ao, albedo, normal);
-    float3 directLighting = getDirectLighting(normal, position.xyz, albedo, metallic, roughness);
+    float3 directLighting = getDirectLighting(normal, position.xyz, albedo, metallic, roughness, true);
     
     float3 lighting = ambientLighting + directLighting;
     float3 clampLighting = clamp(lighting, 0.0f, 1000.0f);
@@ -55,7 +55,7 @@ float4 mainMSAA(psInput input) : SV_TARGET
         float roughness = 0.98;
         
         float3 ambientLighting = getAmbientLighting(ao, albedo, normal);
-        float3 directLighting = getDirectLighting(normal, position.xyz, albedo, metallic, roughness);
+        float3 directLighting = getDirectLighting(normal, position.xyz, albedo, metallic, roughness, true);
         
         float3 lighting = ambientLighting + directLighting;
         float3 clampLighting = clamp(lighting, 0.0f, 1000.0f);

--- a/voxen/ShadingBasicPS.hlsl
+++ b/voxen/ShadingBasicPS.hlsl
@@ -21,7 +21,9 @@ float4 main(psInput input) : SV_TARGET
     albedo += albedoTex.Load(input.posProj.xy, 2).rgb;
     albedo += albedoTex.Load(input.posProj.xy, 3).rgb;
     albedo /= SAMPLE_COUNT;
+    
     float ao = ssaoTex.Sample(pointClampSS, input.texcoord).r;
+    ao = pow(ao, 2.0);
     
     // todo
     float metallic = 0.0;
@@ -48,7 +50,9 @@ float4 mainMSAA(psInput input) : SV_TARGET
         float3 normal = normalEdgeTex.Load(input.posProj.xy, i).xyz;
         float4 position = positionTex.Load(input.posProj.xy, i);
         float3 albedo = albedoTex.Load(input.posProj.xy, i).rgb; 
+        
         float ao = ssaoTex.Sample(pointClampSS, input.texcoord).r;
+        ao = pow(ao, 2.0);
         
         // todo
         float metallic = 0.0;

--- a/voxen/Structure.h
+++ b/voxen/Structure.h
@@ -78,11 +78,9 @@ struct BlurConstantData {
 };
 
 struct ShadowConstantData {
-	Matrix viewProj[3];
-	float topLX[3];
-	float dummy1;
-	float viewWith[3];
-	float dummy2;
+	Matrix viewProj[4];
+	float topLX[4];
+	float viewWidth[4];
 };
 
 struct FogFilterConstantData {

--- a/voxen/Structure.h
+++ b/voxen/Structure.h
@@ -80,7 +80,9 @@ struct BlurConstantData {
 struct ShadowConstantData {
 	Matrix viewProj[4];
 	float topLX[4];
-	float viewWidth[4];
+	float viewportWidth[4];
+	float frustumWidth[4];
+	float frustumHeight[4];
 };
 
 struct FogFilterConstantData {

--- a/voxen/Structure.h
+++ b/voxen/Structure.h
@@ -78,11 +78,9 @@ struct BlurConstantData {
 };
 
 struct ShadowConstantData {
-	Matrix viewProj[4];
+	Matrix viewProj[3];
 	float topLX[4];
 	float viewportWidth[4];
-	float frustumWidth[4];
-	float frustumHeight[4];
 };
 
 struct FogFilterConstantData {

--- a/voxen/WaterPlanePS.hlsl
+++ b/voxen/WaterPlanePS.hlsl
@@ -33,7 +33,7 @@ float4 main(psInput input, uint sampleIndex : SV_SampleIndex) : SV_TARGET
     float3 textureColor = atlasTextureArray.Sample(pointWrapSS, float3(input.texcoord, 0)).rgb;
     float3 ambientLighting = getAmbientLighting(1.0, textureColor, input.normal);
     
-    float3 directLighting = getDirectLighting(input.normal, input.posWorld, textureColor, 0.0, 0.05);
+    float3 directLighting = getDirectLighting(input.normal, input.posWorld, textureColor, 0.0, 0.05, true);
     
     float3 waterColor = ambientLighting + directLighting;
     

--- a/voxen/imgui.ini
+++ b/voxen/imgui.ini
@@ -3,6 +3,6 @@ Pos=60,60
 Size=400,400
 
 [Window][Scene Control]
-Pos=1387,9
-Size=595,102
+Pos=1409,6
+Size=595,109
 

--- a/voxen/imgui.ini
+++ b/voxen/imgui.ini
@@ -3,6 +3,6 @@ Pos=60,60
 Size=400,400
 
 [Window][Scene Control]
-Pos=1326,9
-Size=602,103
+Pos=1387,9
+Size=595,102
 

--- a/voxen/imgui.ini
+++ b/voxen/imgui.ini
@@ -3,6 +3,6 @@ Pos=60,60
 Size=400,400
 
 [Window][Scene Control]
-Pos=1579,2
-Size=317,101
+Pos=1315,10
+Size=611,101
 

--- a/voxen/imgui.ini
+++ b/voxen/imgui.ini
@@ -3,6 +3,6 @@ Pos=60,60
 Size=400,400
 
 [Window][Scene Control]
-Pos=1315,10
-Size=611,101
+Pos=1326,9
+Size=602,103
 

--- a/voxen/light.cpp
+++ b/voxen/light.cpp
@@ -8,7 +8,7 @@
 using namespace DirectX::SimpleMath;
 
 Light::Light()
-	: m_position(0.0f), m_dir(cos(Utils::PI / 4.0f), 0.0f, cos(Utils::PI / 4.0f)), m_scale(0.0f),
+	: m_dir(cos(Utils::PI / 4.0f), 0.0f, cos(Utils::PI / 4.0f)), m_scale(0.0f),
 	  m_radianceColor(1.0f), m_radianceWeight(1.0f), m_lightConstantBuffer(nullptr),
 	  m_shadowConstantBuffer(nullptr)
 {
@@ -46,8 +46,6 @@ void Light::Update(UINT dateTime, Camera& camera)
 		m_dir.Normalize();
 
 		m_up = XMVector3TransformNormal(Vector3(0.0f, 1.0f, 0.0f), rotationAxisMatrix);
-
-		m_position = camera.GetPosition() + m_dir * 100.0f;
 
 		// radiance
 		if (dateTime < App::DAY_START)
@@ -122,6 +120,7 @@ void Light::Update(UINT dateTime, Camera& camera)
 		float cascade[CASCADE_NUM + 1] = { 0.0f, 0.015f, 0.05f, 0.125f};
 		float topLX[CASCADE_NUM] = { 0.0f, 1024.0f, 2048.0f };
 		float viewportWidth[CASCADE_NUM] = { 1024.0f, 1024.0f, 1024.0f};
+		float diagonals[CASCADE_NUM] = { 30.0f, 170.0f, 309.0f };
 
 		Matrix cameraViewProjInverse =
 			(camera.GetViewMatrix() * camera.GetProjectionMatrix()).Invert();
@@ -165,20 +164,7 @@ void Light::Update(UINT dateTime, Camera& camera)
 				lightViewCornerMax = XMVectorMax(lightViewCornerMax, lightViewCascadeCorner[j]);
 			}
 			
-			Vector3 diagonal = worldCascadeCorner[6] - worldCascadeCorner[0];
-			diagonal = XMVector3Length(diagonal);
-
-			if (i == 0) {
-				diagonal = Vector3(30.0f);
-			}
-			else if (i == 1) {
-				diagonal = Vector3(170.0f);
-			}
-			else if (i == 2) {
-				diagonal = Vector3(309.0f);
-			}
-			
-
+			Vector3 diagonal(diagonals[i]);
 			float cascadeBound = diagonal.x;
 
 			Vector3 maxminVector = lightViewCornerMax - lightViewCornerMin;

--- a/voxen/light.cpp
+++ b/voxen/light.cpp
@@ -8,8 +8,9 @@
 using namespace DirectX::SimpleMath;
 
 Light::Light()
-	: m_dir(cos(Utils::PI / 4.0f), 0.0f, cos(Utils::PI / 4.0f)), m_scale(0.0f), m_radianceColor(1.0f),
-	  m_radianceWeight(1.0f), m_lightConstantBuffer(nullptr), m_shadowConstantBuffer(nullptr)
+	: m_dir(cos(Utils::PI / 4.0f), 0.0f, cos(Utils::PI / 4.0f)), m_scale(0.0f),
+	  m_radianceColor(1.0f), m_radianceWeight(1.0f), m_lightConstantBuffer(nullptr),
+	  m_shadowConstantBuffer(nullptr)
 {
 }
 
@@ -40,7 +41,8 @@ void Light::Update(UINT dateTime, Camera& camera)
 		Matrix rotationAxisMatrix = Matrix::CreateFromAxisAngle(
 			Vector3(-cos(Utils::PI / 4.0f), 0.0f, cos(Utils::PI / 4.0f)), angle);
 
-		m_dir = Vector3::Transform(Vector3(cos(Utils::PI / 4.0f), 0.0f, cos(Utils::PI / 4.0f)), rotationAxisMatrix);
+		m_dir = Vector3::Transform(
+			Vector3(cos(Utils::PI / 4.0f), 0.0f, cos(Utils::PI / 4.0f)), rotationAxisMatrix);
 		m_dir.Normalize();
 
 		m_up = XMVector3TransformNormal(Vector3(0.0f, 1.0f, 0.0f), rotationAxisMatrix);
@@ -95,8 +97,9 @@ void Light::Update(UINT dateTime, Camera& camera)
 			}
 
 			if (App::MAX_SUNRISE <= dateTime && dateTime < App::DAY_START + App::DAY_CYCLE_AMOUNT) {
-				float radianceColorFactor = (float)(dateTime - App::MAX_SUNRISE) /
-											(App::DAY_START + App::DAY_CYCLE_AMOUNT - App::MAX_SUNRISE);
+				float radianceColorFactor =
+					(float)(dateTime - App::MAX_SUNRISE) /
+					(App::DAY_START + App::DAY_CYCLE_AMOUNT - App::MAX_SUNRISE);
 
 				m_radianceColor =
 					Utils::Lerp(RADIANCE_SUNRISE_COLOR, RADIANCE_DAY_COLOR, radianceColorFactor);
@@ -114,26 +117,19 @@ void Light::Update(UINT dateTime, Camera& camera)
 
 	// shadow
 	{
-		float cascade[CASCADE_NUM + 1] = { 0.0f, 0.02f, 0.05f, 0.1f };
-		float topLX[CASCADE_NUM] = { 0.0f, 1536.0f, 2816.0f};
-		float viewportWith[CASCADE_NUM] = { 1536.0f, 1080.0f, 1024.0f };
-		
-		if (angle >= Utils::PI / 2.0f)
-		{
+		float cascade[CASCADE_NUM + 1] = { 0.0f, 0.025f, 0.1f, 0.3f, 0.5f };
+		float topLX[CASCADE_NUM] = { 0.0f, 2048.0f, 3072.0f, 3584.0f };
+		float viewportWidth[CASCADE_NUM] = { 2048.0f, 1024.0f, 512.0f, 256.0f };
+
+		if (angle >= Utils::PI / 2.0f) {
 			m_up *= -1;
 		}
 
-		Vector3 frustum[8]{
-			{ -1.0f, 1.0f, 0.0f },
-			{ 1.0f, 1.0f, 0.0f }, 
-			{ 1.0f, -1.0f, 0.0f },
+		Vector3 frustum[8]{ { -1.0f, 1.0f, 0.0f }, { 1.0f, 1.0f, 0.0f }, { 1.0f, -1.0f, 0.0f },
 			{ -1.0f, -1.0f, 0.0f },
 
-			{ -1.0f, 1.0f, 1.0f },
-			{ 1.0f, 1.0f, 1.0f },
-			{ 1.0f, -1.0f, 1.0f },
-			{ -1.0f, -1.0f, 1.0f } 
-		};
+			{ -1.0f, 1.0f, 1.0f }, { 1.0f, 1.0f, 1.0f }, { 1.0f, -1.0f, 1.0f },
+			{ -1.0f, -1.0f, 1.0f } };
 
 		Matrix toWorld = (camera.GetViewMatrix() * camera.GetProjectionMatrix()).Invert();
 
@@ -142,20 +138,18 @@ void Light::Update(UINT dateTime, Camera& camera)
 
 		for (int i = 0; i < CASCADE_NUM; ++i) {
 			Vector3 tFrustum[8];
-			for (int j = 0; j < 8; ++j)
-				tFrustum[j] = frustum[j];
 
 			for (int j = 0; j < 4; ++j) {
-				Vector3 v = tFrustum[j + 4] - tFrustum[j];
+				Vector3 v = frustum[j + 4] - frustum[j];
 
 				Vector3 n = v * cascade[i];
 				Vector3 f = v * cascade[i + 1];
 
-				tFrustum[j + 4] = tFrustum[j] + f;
-				tFrustum[j] = tFrustum[j] + n;
+				tFrustum[j] = frustum[j] + n;
+				tFrustum[j + 4] = frustum[j] + f;
 			}
 
-			Vector3 center;
+			Vector3 center = Vector3(0.0f);
 			for (auto& v : tFrustum)
 				center += v;
 			center *= 1.0f / 8.0f;
@@ -163,38 +157,25 @@ void Light::Update(UINT dateTime, Camera& camera)
 			float radius = 0.0f;
 			for (auto& v : tFrustum)
 				radius = max(radius, (v - center).Length());
+
 			radius = std::ceil(radius * 16.0f) / 16.0f;
 			
-			float value = max(500.0f, radius * 2.0f);
-			Vector3 sunPos = center + (-m_dir * -value);
+			Vector3 sunPos = center + (m_dir * radius * 2.0f);
+
+			float farZ = (sunPos - center).Length() + radius;
 
 			m_view[i] = XMMatrixLookAtLH(sunPos, center, m_up);
-			m_proj[i] = XMMatrixOrthographicLH(radius * 2.0f, radius * 2.0f, 0.0f, 2000.0f);
-
-			Vector3 shadowOrigin = Vector3(0.0f, 0.0f, 0.0f);
-			shadowOrigin = Vector3::Transform(shadowOrigin, (m_view[i] * m_proj[i]));
-			shadowOrigin.x *= App::SHADOW_WIDTH * 0.5f + App::SHADOW_WIDTH * 0.5f;
-			shadowOrigin.y *= App::SHADOW_HEIGHT * 0.5f + App::SHADOW_HEIGHT * 0.5f;
-
-			Vector3 roundedOrigin =
-				Vector3(round(shadowOrigin.x), round(shadowOrigin.y), shadowOrigin.z);
-			Vector3 roundOffset =
-				Vector3((roundedOrigin.x - shadowOrigin.x) * (2.0f / App::SHADOW_WIDTH),
-					(roundedOrigin.y - shadowOrigin.y) * (2.0f / App::SHADOW_HEIGHT),
-					0.0f);
-
+			m_proj[i] = XMMatrixOrthographicLH(radius * 2.0f, radius * 2.0f, 0.0f, farZ);
 			Matrix viewProj = m_view[i] * m_proj[i];
-			viewProj._41 += roundOffset.x;
-			viewProj._42 += roundOffset.y;
 
 			m_shadowConstantData.viewProj[i] = viewProj.Transpose();
 			m_shadowConstantData.topLX[i] = topLX[i];
-			m_shadowConstantData.viewWith[i] = viewportWith[i];
+			m_shadowConstantData.viewWidth[i] = viewportWidth[i];
 
 			DXUtils::UpdateViewport(m_shadowViewPorts[i], m_shadowConstantData.topLX[i], 0.0f,
-					m_shadowConstantData.viewWith[i], m_shadowConstantData.viewWith[i]);
+				m_shadowConstantData.viewWidth[i], m_shadowConstantData.viewWidth[i]);
 		}
-
+		std::cout << std::endl;
 		DXUtils::UpdateConstantBuffer(m_shadowConstantBuffer, m_shadowConstantData);
 	}
 }

--- a/voxen/light.cpp
+++ b/voxen/light.cpp
@@ -117,9 +117,9 @@ void Light::Update(UINT dateTime, Camera& camera)
 
 	// shadow
 	{
-		float cascade[CASCADE_NUM + 1] = { 0.0f, 0.025f, 0.1f, 0.3f, 0.5f };
-		float topLX[CASCADE_NUM] = { 0.0f, 2048.0f, 3072.0f, 3584.0f };
-		float viewportWidth[CASCADE_NUM] = { 2048.0f, 1024.0f, 512.0f, 256.0f };
+		float cascade[CASCADE_NUM + 1] = { 0.0f, 0.01f, 0.03f, 0.1f, 0.3f };
+		float topLX[CASCADE_NUM] = { 0.0f, 1024.0f, 1536.0f, 1792.0f };
+		float viewportWidth[CASCADE_NUM] = { 1024.0f, 512.0f, 256.0f, 128.0f };
 
 		if (angle >= Utils::PI / 2.0f) {
 			m_up *= -1;
@@ -160,7 +160,7 @@ void Light::Update(UINT dateTime, Camera& camera)
 
 			radius = std::ceil(radius * 16.0f) / 16.0f;
 			
-			Vector3 sunPos = center + (m_dir * radius * 2.0f);
+			Vector3 sunPos = center + (m_dir * radius * 1.0f);
 
 			float farZ = (sunPos - center).Length() + radius;
 

--- a/voxen/light.h
+++ b/voxen/light.h
@@ -12,7 +12,7 @@ using namespace Microsoft::WRL;
 class Light {
 
 public:
-	static const int CASCADE_NUM = 4;
+	static const int CASCADE_NUM = 3;
 
 	Light();
 	~Light();
@@ -30,18 +30,17 @@ public:
 
 	D3D11_VIEWPORT m_shadowViewPorts[CASCADE_NUM];
 
-	inline Matrix GetViewMatrix(int i) { return m_view[i]; };
-	inline Matrix GetProjectionMatrix(int i) { return m_proj[i]; };
+	inline Matrix GetViewMatrix() { return XMMatrixLookToLH(m_position, -m_dir, m_up); }
+	inline Matrix GetProjectionMatrixFromCascade(int i) { return m_proj[i]; };
 
 private:
+	Vector3 m_position;
 	Vector3 m_dir;
 	float m_scale;
 	Vector3 m_radianceColor;
 	float m_radianceWeight;
 
 	Vector3 m_up;
-
-	Matrix m_view[CASCADE_NUM];
 	Matrix m_proj[CASCADE_NUM];
 
 	const Vector3 RADIANCE_DAY_COLOR = Vector3(1.0f, 1.0f, 1.0f);

--- a/voxen/light.h
+++ b/voxen/light.h
@@ -12,6 +12,8 @@ using namespace Microsoft::WRL;
 class Light {
 
 public:
+	static const int CASCADE_NUM = 4;
+
 	Light();
 	~Light();
 
@@ -26,7 +28,7 @@ public:
 	ComPtr<ID3D11Buffer> m_shadowConstantBuffer;
 	ShadowConstantData m_shadowConstantData;
 
-	D3D11_VIEWPORT m_shadowViewPorts[3];
+	D3D11_VIEWPORT m_shadowViewPorts[CASCADE_NUM];
 
 	inline Matrix GetViewMatrix(int i) { return m_view[i]; };
 	inline Matrix GetProjectionMatrix(int i) { return m_proj[i]; };
@@ -39,10 +41,9 @@ private:
 
 	Vector3 m_up;
 
-	Matrix m_view[3];
-	Matrix m_proj[3];
+	Matrix m_view[CASCADE_NUM];
+	Matrix m_proj[CASCADE_NUM];
 
-	static const int CASCADE_NUM = 3;
 	const Vector3 RADIANCE_DAY_COLOR = Vector3(1.0f, 1.0f, 1.0f);
 	const Vector3 RADIANCE_SUNRISE_COLOR = Vector3(0.72f, 0.60f, 0.34f);
 	const Vector3 RADIANCE_SUNSET_COLOR = Vector3(0.64f, 0.26f, 0.04f);

--- a/voxen/light.h
+++ b/voxen/light.h
@@ -30,11 +30,10 @@ public:
 
 	D3D11_VIEWPORT m_shadowViewPorts[CASCADE_NUM];
 
-	inline Matrix GetViewMatrix() { return XMMatrixLookToLH(m_position, -m_dir, m_up); }
+	inline Matrix GetViewMatrix() { return XMMatrixLookToLH(Vector3::Zero, -m_dir, m_up); }
 	inline Matrix GetProjectionMatrixFromCascade(int i) { return m_proj[i]; };
 
 private:
-	Vector3 m_position;
 	Vector3 m_dir;
 	float m_scale;
 	Vector3 m_radianceColor;


### PR DESCRIPTION
close #82 

## 작업 내용
- **Shimmering (flickering) 제거**
  - MicroSoft Sample 참고
  - Padding Offset 값을 Static하게 지정
  - Light View Matrix의 Position은 `Vector3::Zero`로 정적으로 설정해도 됨
   ```
   Vector3 lightViewCornerMin = Vector3(D3D11_FLOAT32_MAX);
   Vector3 lightViewCornerMax = Vector3(-D3D11_FLOAT32_MAX);
   for (int j = 0; j < 8; ++j) {
	    lightViewCornerMin = XMVectorMin(lightViewCornerMin, lightViewCascadeCorner[j]);
	    lightViewCornerMax = XMVectorMax(lightViewCornerMax, lightViewCascadeCorner[j]);
   }
    
  Vector3 diagonal(diagonals[i]); // 정적인 대각선 값 (worldFrustumCorner[6] - worldFrustumCorner[0]).Length
  float cascadeBound = diagonals[i];
  
  Vector3 maxminVector = lightViewCornerMax - lightViewCornerMin;
  Vector3 borderOffset = (diagonal - maxminVector) * 0.5f;
  
  lightViewCornerMax += borderOffset;
  lightViewCornerMin -= borderOffset;
  
  float worldUnitsPerTexel = cascadeBound / viewportWidth[i];
  
  lightViewCornerMin /= worldUnitsPerTexel;
  lightViewCornerMin = XMVectorFloor(lightViewCornerMin);
  lightViewCornerMin *= worldUnitsPerTexel;
  
  lightViewCornerMax /= worldUnitsPerTexel;
  lightViewCornerMax = XMVectorFloor(lightViewCornerMax);
  lightViewCornerMax *= worldUnitsPerTexel;
  
  m_proj[i] = XMMatrixOrthographicOffCenterLH(lightViewCornerMin.x, lightViewCornerMax.x,
	  lightViewCornerMin.y, lightViewCornerMax.y, lightViewCornerMin.z,
	  lightViewCornerMax.z);
   ```

- **Cascade간 경계 문제 제거**
  - Depth Clip을 하지 않고 사용 -> 원래 Clip 되어야하는 곳의 Depth가 `0.0`으로 픽스됨
  - margin(혹은 padding)을 둬서 경계면에서 PCF를 하여 원치 않는 결과를 없앰
  ```
  float4 lightProj = mul(float4(posWorld, 1.0), shadowViewProj[i]);
  lightProj.xyz /= lightProj.w;
  
  if (lightProj.x < -1.0 + pcfMargin || lightProj.x > 1.0 - pcfMargin ||
      lightProj.y < -1.0 + pcfMargin || lightProj.y > 1.0 - pcfMargin ||
      lightProj.z < 0.0 + pcfMargin  || lightProj.z > 1.0 - pcfMargin)
  {
      continue;
  }
  ```

- **Acne 제거를 위한 Bias 조정**
  - Light Strength에 따른 그림자 세기 조정하여 낮은 고도일 때 그림자가 덜 맺히도록 유도
  - 각도에 따른 Bias를 조정
  ```
  float bias = 0.001 + 0.01 * pow(1.0 - max(dot(lightDir, normal), 0.0), 3.0);
  ```

## 추가 작업
- **원래 `DAY_START`부터 Light Strength가 MAX 값이였던 것을 `NIGHT_END`부터 12시 정오까지 MAX 값으로 보간**
  ```
  if (App::NIGHT_START <= dateTime && dateTime < App::NIGHT_END) {
	  m_radianceWeight = 0.0f;
  }
  else {
	  float currentAltitude = m_dir.y;
	  float nightEndAltitude = -1.7f / 12.0f * Utils::PI;
	  
	  float w = (currentAltitude - nightEndAltitude) / (1.0f - nightEndAltitude);
  
	  m_radianceWeight = Utils::Smootherstep(0.0f, MAX_RADIANCE_WEIGHT, w);
  }
  ```
